### PR TITLE
Issue #153: per-device OPC UA SourceTimestamp mode (server|device)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Per-device OPC UA `SourceTimestamp` mode**
+  ([#153](https://github.com/guycorbaz/opcgw/issues/153)). New per-device
+  `source_timestamp_server` flag (web-UI checkbox in Config → device,
+  `source_timestamp_server` in `config.toml`, and the `source_timestamp_server`
+  field on the device CRUD API). When `true`, opcgw stamps that device's served
+  values with the gateway's current time (`now()`) instead of the device's real
+  report time. This fixes SCADA clients (notably **Ignition**) that overlay a
+  *Stale / Uncertain* quality on any value whose OPC UA `SourceTimestamp` is
+  older than a client-side window — slow-cadence LoRaWAN devices (e.g. a 20-min
+  uplink interval) otherwise read Uncertain between uplinks even though opcgw
+  returns `Good`, and raising `stale_threshold_seconds` does not help because
+  that knob only governs opcgw's own `StatusCode`, not the client's timestamp
+  interpretation. Diagnosed live on the panoramix deployment against Ignition
+  8.3 by reading the OPC UA server directly (all nodes served `Good` on both
+  reads and subscriptions — the Uncertain was entirely client-side). Default is
+  `false` (strict OPC UA semantics; unchanged behaviour for every existing
+  device). The staleness `StatusCode` model is unaffected: a device that
+  genuinely stops reporting past its stale threshold still flips to `Uncertain`.
+  Schema migration **v014** adds the `devices.source_timestamp_server` column.
+
 ## [2.6.1] — 2026-07-08 — Storage-latency budget fix
 
 > **Status:** released. Patch release fixing a regression found during the

--- a/README.md
+++ b/README.md
@@ -329,6 +329,19 @@ appear as "Missing" rather than being silently omitted — operators
 spot mis-configured devices at a glance. Same 10 s refresh + responsive
 layout + dark mode as the dashboard. JSON contract at `GET /api/devices`.
 
+**Per-device OPC UA `SourceTimestamp` mode ([#153](https://github.com/guycorbaz/opcgw/issues/153)).**
+By default opcgw stamps each served value's OPC UA `SourceTimestamp` with the
+device's own report time (strict OPC UA semantics). Some SCADA clients (notably
+**Ignition**) overlay a *Stale / Uncertain* quality on any value whose source
+timestamp is older than a client-side window — so slow-cadence LoRaWAN devices
+(e.g. a 20-minute uplink interval) read Uncertain between uplinks even though
+opcgw returns `Good`. The per-device **"Use server time as source timestamp"**
+checkbox (Config → device, or `source_timestamp_server = true` in `config.toml`,
+or the `source_timestamp_server` field on the device CRUD API) makes opcgw stamp
+`now()` instead, keeping the tag Good in those clients. The staleness *status
+code* is unaffected — a device that genuinely stops reporting past its stale
+threshold still flips to Uncertain.
+
 **Story F-4 adds config export / import.** From the singleton-configuration
 page, **Export config** downloads the whole configuration — the `[global]` /
 `[chirpstack]` / `[opcua]` / `[web]` sections plus the application/device/metric/

--- a/config/config.toml
+++ b/config/config.toml
@@ -254,6 +254,19 @@ application_name = "Example"
     [[application.device]]
     device_name = "WaterFlowSensor"
     device_id = "a84041b8a1867e20"
+    # Optional per-device staleness override (seconds). Absent = use the global
+    # [opcua].stale_threshold_seconds. Set it above the device's report period so
+    # a slow LoRaWAN sensor reads Good instead of Uncertain between uplinks.
+    #stale_threshold_seconds = 2700
+    # Issue #153: per-device OPC UA SourceTimestamp mode. false (default) stamps
+    # each served value with the device's real report time (strict OPC UA
+    # semantics). true stamps the gateway's current time (now()) so SCADA clients
+    # (e.g. Ignition) that mark a tag Uncertain/Stale when the source timestamp is
+    # older than their window keep it Good — common on slow-cadence LoRaWAN
+    # devices. The staleness status code is unaffected: a device that genuinely
+    # stops reporting past its stale threshold still flips to Uncertain. Also
+    # settable per device from the web UI (Config → device → checkbox).
+    #source_timestamp_server = false
 
         [[application.device.read_metric]]
         metric_name = "WaterFlow"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,6 +296,7 @@ Define devices under an application.
 | `device_name` | string | ✓ | Display name in OPC UA |
 | `device_id` | string | ✓ | ChirpStack device ID |
 | `stale_threshold_seconds` | u64 | ✗ | Per-device override of `[opcua].stale_threshold_seconds`. Range `(0, 86400]`. Set above the device's report period so a slow-but-healthy LoRaWAN sensor reads `Good` between uplinks. `None` = use the global. Restart-required. |
+| `source_timestamp_server` | bool | ✗ | Issue #153: per-device OPC UA `SourceTimestamp` mode. `false` (default) stamps served values with the device's real report time (strict OPC UA semantics). `true` stamps the gateway's current time (`now()`) so SCADA clients (e.g. Ignition) that flag old source timestamps keep the tag `Good` — common on slow-cadence LoRaWAN devices. Does **not** change the staleness `StatusCode` (a genuinely dead device still reads `Uncertain`). Settable from the web UI checkbox. Restart-required (Apply). |
 
 ### Validation Rules
 

--- a/docs/manual/opcgw-user-manual.xml
+++ b/docs/manual/opcgw-user-manual.xml
@@ -1,0 +1,4105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+  "http://www.docbook.org/xml/4.5/docbookx.dtd">
+<book>
+
+  <bookinfo>
+    <mediaobject>
+      <imageobject>
+        <imagedata fileref="../logo/opcgw-horizontal.svg" format="SVG" width="400" align="center"/>
+      </imageobject>
+      <textobject>
+        <phrase>opcgw — ChirpStack to OPC UA Gateway</phrase>
+      </textobject>
+    </mediaobject>
+    <title>opcgw User Manual</title>
+    <subtitle>ChirpStack LoRaWAN to OPC UA Gateway</subtitle>
+    <author>
+      <firstname>Guy</firstname>
+      <surname>Corbaz</surname>
+      <email>gcorbaz@gmail.com</email>
+    </author>
+    <copyright>
+      <year>2024</year>
+      <year>2026</year>
+      <holder>Guy Corbaz</holder>
+    </copyright>
+    <legalnotice>
+      <para>This work is licensed under MIT OR Apache-2.0 license.</para>
+    </legalnotice>
+    <revhistory>
+      <revision>
+        <revnumber>1.0.0</revnumber>
+        <date>2026-04-20</date>
+        <authorinitials>GC</authorinitials>
+        <revremark>Initial release of opcgw user manual</revremark>
+      </revision>
+      <revision>
+        <revnumber>2.0.0</revnumber>
+        <date>2026-04-27</date>
+        <authorinitials>GC</authorinitials>
+        <revremark>Comprehensive update covering Epics 2-6: SQLite-backed persistence
+        (WAL mode, connection pool), command queue with delivery confirmation,
+        gRPC pagination, support for all metric types, gateway health metrics in
+        OPC UA, stale-data status codes (Good/Uncertain/Bad), structured logging
+        with microsecond timestamps + correlation IDs, configurable verbosity,
+        performance-budget warnings, and remote-diagnostic operation taxonomy.
+        Configuration chapter rewritten against actual TOML keys; new chapters
+        on Logging &amp; Observability and Operational Monitoring; new appendices
+        for configuration reference, OPC UA address space, and operation
+        names.</revremark>
+      </revision>
+      <revision>
+        <revnumber>2.0.0-GA</revnumber>
+        <date>2026-05-19</date>
+        <authorinitials>GC</authorinitials>
+        <revremark>v2.0 GA Release. Adds Epic 7 (OPC UA security
+        hardening: three-endpoint matrix, private-key permission
+        enforcement, max_connections session cap, opcua_auth_failed and
+        opcua_session_count_at_limit audit events); Epic 8 (real-time
+        subscriptions with DataChangeFilter, configurable subscription
+        and message-size limits, OPC UA HistoryRead and
+        max_history_data_results_per_node); Epic 9 (embedded Axum Web
+        UI behind HTTP Basic auth, dashboard and live metrics page,
+        configuration hot-reload via SIGHUP, CRUD endpoints for
+        applications, devices, and commands); Epic A (storage payload
+        migration closing issue #108 — payload-bearing MetricType, v007
+        and v008 SQLite migrations, NaN/Inf poller filter, real
+        measurement values round-tripped end-to-end for the first
+        time). New Installation, Upgrade and Migration chapters;
+        Configuration chapter extended for [opcua].max_connections,
+        [web], and the audit-event reason taxonomy. Docker Hub
+        (docker.io/gcorbaz/opcgw) and GHCR mirror
+        (ghcr.io/guycorbaz/opcgw) publishing documented; Dockerfile
+        pinned to ubuntu:24.04 and runs as non-root opcgw user (UID
+        10001).</revremark>
+      </revision>
+      <revision>
+        <revnumber>2.1.0</revnumber>
+        <date>2026-05-28</date>
+        <authorinitials>GC</authorinitials>
+        <revremark>Web-first configuration and auto-discovery. Epic C
+        (first-run setup wizard, ChirpStack inventory query layer and web
+        UI pickers, duplicate-prevention validator, inventory drift view,
+        and the TOML-to-SQLite migration of applications, devices,
+        metrics, and commands); Epic D (singleton
+        [global]/[chirpstack]/[opcua]/[web] configuration moved into
+        SQLite with a web editor, and decommissioning of the TOML
+        write-back / SIGHUP hot-reload surface). Configuration now lives
+        in SQLite and is managed from the web UI; config.toml is a
+        one-time bootstrap seed. Schema advanced to v010. Configuration
+        precedence: environment variable &gt; SQLite &gt; config.toml &gt;
+        default.</revremark>
+      </revision>
+    </revhistory>
+    <abstract>
+      <para>opcgw is a Rust-based gateway that bridges ChirpStack LoRaWAN
+      Network Server with OPC UA clients for industrial automation and SCADA
+      systems. It polls device metrics from ChirpStack at configurable
+      intervals, persists them in a local SQLite database (WAL mode for
+      concurrent reads), exposes them via OPC UA 1.04 with stale-data status
+      codes, real-time subscriptions, and HistoryRead, and accepts downlink
+      commands from OPC UA clients with end-to-end delivery confirmation. An
+      embedded Axum web UI — enabled by default and the primary configuration
+      surface as of v2.1.0 — provides a first-run setup wizard, ChirpStack
+      inventory pickers, a configuration editor, and live status / metric
+      views. Configuration is stored in SQLite; config.toml is a one-time
+      bootstrap seed. As of v2.1.0 the gateway persists real typed measurement
+      payloads end-to-end. This manual provides comprehensive guidance on
+      installation, configuration, operation, observability, troubleshooting,
+      and upgrade / migration.</para>
+    </abstract>
+  </bookinfo>
+
+  <!-- ============================================ -->
+  <!-- CHAPTER: OVERVIEW -->
+  <!-- ============================================ -->
+  <chapter id="ch-overview">
+      <title>Overview</title>
+
+      <section id="sec-what-is-opcgw">
+        <title>What is opcgw?</title>
+        <para>opcgw (OPC Gateway) is a middleware application that bridges the
+        gap between LoRaWAN sensor networks and industrial automation
+        systems. It provides bidirectional integration between:</para>
+        <itemizedlist>
+          <listitem>
+            <para><emphasis>ChirpStack LoRaWAN Network Server</emphasis> —
+            Manages LoRaWAN devices, gathers uplink metrics from distributed
+            IoT sensors, and accepts downlink commands.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>OPC UA Clients</emphasis> — SCADA systems,
+            industrial controllers, and human-machine interfaces that consume
+            metrics in real time and issue commands.</para>
+          </listitem>
+        </itemizedlist>
+        <para>The gateway continuously polls device metrics from ChirpStack,
+        persists them in a local SQLite database with WAL-mode concurrency,
+        exposes the current values plus gateway health as OPC UA variables,
+        and queues outbound commands for reliable delivery.</para>
+      </section>
+
+      <section id="sec-key-features">
+        <title>Key Features</title>
+        <itemizedlist>
+          <listitem>
+            <para><emphasis>Real-time data collection</emphasis> — Polls
+            device metrics from ChirpStack at configurable intervals and
+            exposes them as boolean, integer, float, and string
+            values.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Persistent storage</emphasis> — Metric values
+            and their history are kept in an embedded database, so data
+            survives restarts and remains available for historical
+            analysis.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Command delivery</emphasis> — Send commands
+            (downlinks) to devices through a queue that validates the
+            parameters and tracks each command from pending, through sent,
+            to confirmed or failed. For confirmed downlinks (for example a
+            valve), <emphasis>confirmed</emphasis> means the device
+            acknowledged receipt; opcgw learns this from ChirpStack's live
+            device-event stream. A command that is never acknowledged within
+            the configurable delivery timeout
+            (<literal>command_delivery_timeout_secs</literal>, default 60 s)
+            is marked failed. The current status of recent commands is
+            readable from the OPC UA <literal>CommandStatusQuery</literal>
+            variable.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>OPC UA 1.04 server</emphasis> — Exposes every
+            configured metric to SCADA and automation clients, alongside a
+            <literal>Gateway</literal> folder of health metrics (last poll
+            time, error count, ChirpStack availability). Unencrypted,
+            signed, and signed-and-encrypted endpoints are offered
+            concurrently.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Subscriptions and history</emphasis> — Clients
+            can subscribe to live value changes and read historical values
+            over a configurable time window.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>OPC UA security</emphasis> — User/password
+            authentication, a configurable limit on concurrent client
+            sessions, and enforced filesystem permissions on the OPC UA
+            private key.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Embedded web UI (opt-in)</emphasis> — An
+            optional, password-protected web interface for monitoring live
+            status and metric values and for managing applications,
+            devices, and commands. Disabled by default.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Data-freshness indicators</emphasis> — Each
+            value is tagged <literal>Good</literal>,
+            <literal>Uncertain</literal>, or <literal>Bad</literal> based on
+            its age, so operators can see staleness at a glance without
+            parsing timestamps.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Graceful degradation</emphasis> — Keeps
+            operating when ChirpStack is unreachable or individual devices
+            return errors; errors and outages are surfaced in the logs and
+            as OPC UA health metrics.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Structured logging</emphasis> — Detailed,
+            structured log output with configurable verbosity for
+            monitoring and troubleshooting.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Data retention</emphasis> — Historical metrics
+            and command history are pruned automatically according to
+            configurable retention windows.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Graceful shutdown</emphasis> —
+            <literal>Ctrl-C</literal> (or <literal>SIGTERM</literal>)
+            initiates an orderly shutdown.</para>
+          </listitem>
+        </itemizedlist>
+      </section>
+
+      <section id="sec-system-architecture">
+        <title>System Architecture</title>
+        <para>opcgw runs as a single process built around a few cooperating
+        components that share one embedded SQLite database. The diagram below
+        shows how data moves between them.</para>
+
+        <figure id="fig-architecture">
+          <title>opcgw data flow</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="../images/architecture.svg" format="SVG"
+                         width="100%" align="center"/>
+            </imageobject>
+            <textobject>
+              <phrase>ChirpStack feeds the poller, which writes metric values
+              to the SQLite store. The OPC UA server reads values from the
+              store and serves them to SCADA clients. The web UI reads and
+              writes configuration in the store. Commands written by OPC UA
+              clients travel back through the poller to ChirpStack as
+              downlinks.</phrase>
+            </textobject>
+          </mediaobject>
+        </figure>
+
+        <itemizedlist>
+          <listitem>
+            <para><emphasis>Poller</emphasis> — Connects to ChirpStack over
+            gRPC, polls device metrics on a fixed cadence, validates each
+            value against its configured type, and writes the results to the
+            store. It tracks connectivity and reports outages.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>SQLite store</emphasis> — A single embedded
+            database holds the current metric values, the metric history, and
+            the gateway's own configuration. It survives restarts and is the
+            shared source of truth for every other component.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>OPC UA server</emphasis> — Builds its address
+            space from the configured applications, devices, and metrics;
+            serves each value with a freshness status code; supports
+            subscriptions and historical reads; and accepts client writes that
+            become device commands.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Web UI (optional)</emphasis> — A password-protected
+            web interface for first-run setup, configuration, and live
+            monitoring. Enabled by default; it can be turned off.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Command delivery</emphasis> — Writes received over
+            OPC UA are validated, queued, sent to ChirpStack as downlinks, and
+            tracked from pending through sent to confirmed or failed.</para>
+          </listitem>
+        </itemizedlist>
+      </section>
+  </chapter>
+
+  <!-- ============================================ -->
+  <!-- CHAPTER: SYSTEM REQUIREMENTS -->
+  <!-- ============================================ -->
+  <chapter id="ch-requirements">
+    <title>System Requirements</title>
+
+      <section id="sec-hardware-requirements">
+        <title>Hardware Requirements</title>
+        <para>opcgw is lightweight. Its resource needs scale mainly with the
+        number of variables (metrics) and devices you monitor and how long you
+        retain history, not with a fixed minimum. The guidance below is a
+        starting point; size up for larger fleets.</para>
+        <variablelist>
+          <varlistentry>
+            <term>Processor</term>
+            <listitem>
+              <para>A modest CPU is enough for small and medium fleets. Add
+              cores when you poll many devices, so polling, serving OPC UA,
+              and pruning run in parallel. The published Docker images are
+              64-bit (x86-64 and ARM64); a 32-bit target would require
+              building from source.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Memory</term>
+            <listitem>
+              <para>Scales with the number of variables and devices. A few
+              hundred MB is ample for a small deployment; allow on the order
+              of 2 GB for large fleets (hundreds of devices / thousands of
+              variables). Per-variable overhead is small.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Storage</term>
+            <listitem>
+              <para>Scales with how many variables you store and how long you
+              keep history. The image plus a small database fit in well under
+              100 MB; budget around 1 GB or more if you retain a month of
+              history at a short polling interval. Log files add to this
+              depending on the configured verbosity.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Network</term>
+            <listitem>
+              <para>Outbound TCP to the ChirpStack gRPC endpoint
+              (typically port 8080) and inbound TCP for OPC UA clients
+              (default port 4840).</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+
+      <section id="sec-software-requirements">
+        <title>Software Requirements</title>
+        <itemizedlist>
+          <listitem>
+            <para><emphasis>OS</emphasis> — Linux (Debian, Ubuntu, CentOS,
+            Alpine), macOS, or Windows with Docker. The reference deployment
+            uses Linux containers.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Runtime</emphasis> — Docker, using the published
+            image (<literal>docker.io/gcorbaz/opcgw:2.1</literal>, mirrored at
+            <literal>ghcr.io/guycorbaz/opcgw:2.1</literal>; multi-arch
+            <literal>linux/amd64</literal> + <literal>linux/arm64</literal>).
+            See <xref linkend="ch-installation"/>. Building from source is
+            also possible (Rust 1.94.0+ and the
+            <literal>protobuf-compiler</literal> /
+            <literal>libssl-dev</literal> / <literal>pkg-config</literal>
+            packages) for platforms the prebuilt image does not
+            cover.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>SQLite</emphasis> — bundled via
+            <literal>rusqlite</literal>'s <literal>bundled</literal>
+            feature; no separate SQLite installation is needed at runtime.
+            The <literal>sqlite3</literal> CLI is recommended on the
+            operator host for the migration pre-flight script
+            (<xref linkend="ch-upgrade"/>).</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>ChirpStack</emphasis> — version 4.0 or later
+            with the gRPC API enabled and an API token issued for the
+            target tenant.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Firewall</emphasis> — outbound to ChirpStack
+            (gRPC), inbound to OPC UA clients (port 4840 by default), and
+            inbound to the embedded web UI (default port 8080) if
+            <literal>[web].enabled = true</literal>.</para>
+          </listitem>
+        </itemizedlist>
+      </section>
+    </chapter>
+
+  <!-- ============================================ -->
+  <!-- CHAPTER: INSTALLATION -->
+  <!-- ============================================ -->
+  <chapter id="ch-installation">
+      <title>Installation</title>
+
+      <para>Installation is a <emphasis>one-time</emphasis> task: you do it
+      once to get the gateway running and serving OPC UA. Everyday
+      configuration — adding applications, devices, and metrics — is done
+      afterwards from the web UI and is covered separately in
+      <xref linkend="ch-configuration"/>.</para>
+
+      <para>opcgw is distributed as a Docker image and is installed with
+      Docker Compose. The steps are: create a working directory, write a
+      minimal <filename>docker-compose.yml</filename>, put your secrets in a
+      <filename>.env</filename> file, supply a minimal bootstrap
+      configuration, prepare the directories and the OPC UA keys, then start
+      the gateway and verify it.</para>
+
+      <section id="sec-install-prerequisites">
+        <title>Prerequisites</title>
+        <itemizedlist>
+          <listitem>
+            <para>Docker Engine with the Compose plugin
+            (<command>docker compose</command>). See
+            <ulink url="https://docs.docker.com/get-docker/">docker.com</ulink>.</para>
+          </listitem>
+          <listitem>
+            <para>A reachable ChirpStack server and an API token with
+            permission to list applications/devices and read metrics for
+            your tenant.</para>
+          </listitem>
+          <listitem>
+            <para>Two free host ports: <literal>4840</literal> (OPC UA) and
+            <literal>8080</literal> (web UI).</para>
+          </listitem>
+        </itemizedlist>
+      </section>
+
+      <section id="sec-install-compose">
+        <title>The docker-compose.yml file</title>
+        <para>Create a working directory and a
+        <filename>docker-compose.yml</filename> inside it. A minimal file is
+        all you need:</para>
+        <programlisting>services:
+  opcgw:
+    image: docker.io/gcorbaz/opcgw:2.1
+    container_name: opcgw
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "4840:4840"   # OPC UA
+      - "8080:8080"   # web UI
+    volumes:
+      - ./config:/usr/local/bin/config   # config.toml + secrets.toml
+      - ./pki:/usr/local/bin/pki         # OPC UA certificates
+      - ./data:/usr/local/bin/data       # SQLite database (must persist)
+      - ./log:/usr/local/bin/log         # log files</programlisting>
+        <para>Notes:</para>
+        <itemizedlist>
+          <listitem>
+            <para><literal>env_file: .env</literal> loads <emphasis>all</emphasis>
+            environment variables from a single <filename>.env</filename> file
+            (next section). Nothing is configured inside the compose file
+            itself.</para>
+          </listitem>
+          <listitem>
+            <para>The <filename>data</filename> volume holds the SQLite
+            database and <emphasis>must</emphasis> persist. Without it, every
+            <command>docker compose down</command> destroys your stored
+            metrics, history, and configuration.</para>
+          </listitem>
+          <listitem>
+            <para>Pin a version tag. There is no <literal>:latest</literal>
+            tag — use a minor line such as <literal>:2.1</literal> (latest
+            patch) or an exact release such as <literal>:2.1.0</literal>. The
+            image runs as the non-root user <literal>opcgw</literal>
+            (UID 10001).</para>
+          </listitem>
+          <listitem>
+            <para>To pull from the GitHub Container Registry mirror instead of
+            Docker Hub, change the image to
+            <literal>ghcr.io/guycorbaz/opcgw:2.1</literal>. Both registries
+            carry identical multi-architecture
+            (<literal>amd64</literal>/<literal>arm64</literal>)
+            images.</para>
+          </listitem>
+        </itemizedlist>
+      </section>
+
+      <section id="sec-install-env">
+        <title>Environment variables and the .env file</title>
+        <para>All of the gateway's environment configuration lives in one
+        <filename>.env</filename> file next to
+        <filename>docker-compose.yml</filename>. The repository ships a
+        <filename>.env.example</filename> template; copy it and fill in your
+        values:</para>
+        <screen>cp .env.example .env
+$EDITOR .env
+chmod 600 .env</screen>
+        <para>Two variables are <emphasis>required</emphasis> — they are your
+        secrets, which is why they are supplied as environment variables
+        rather than committed to a file:</para>
+        <programlisting>OPCGW_CHIRPSTACK__API_TOKEN=&lt;your-chirpstack-api-token&gt;
+OPCGW_OPCUA__USER_PASSWORD=&lt;a-strong-password&gt;</programlisting>
+        <para>The password is used both for the OPC UA user login and for the
+        web UI's login. Every variable uses the <literal>OPCGW_</literal>
+        prefix, with <literal>__</literal> (double underscore) separating
+        nested configuration keys. Any configuration value can be set this
+        way; the variables most deployments touch (ChirpStack address, OPC UA
+        user name, web-UI enable, log level) are listed in
+        <filename>.env.example</filename>, and the
+        <emphasis>complete</emphasis> list is in
+        <xref linkend="app-env-reference"/>.</para>
+        <warning>
+          <title>Keep secrets out of version control</title>
+          <para>Never commit a populated <filename>.env</filename> or bake
+          tokens into the image. <filename>.env</filename> is git-ignored;
+          set its mode to <literal>0600</literal>. For Kubernetes or a secret
+          manager, inject the same <literal>OPCGW_*</literal> variables by
+          your platform's mechanism instead of a file.</para>
+        </warning>
+      </section>
+
+      <section id="sec-install-bootstrap-config">
+        <title>The bootstrap configuration file</title>
+        <para>opcgw keeps its runtime configuration in its SQLite database and
+        is configured from the web UI. On a fresh install it needs a small
+        <filename>config/config.toml</filename> to seed the very first boot;
+        after that the database is authoritative and you manage everything
+        from the web UI (see <xref linkend="ch-configuration"/>).</para>
+        <para>A minimal seed only needs to point the gateway at your
+        ChirpStack server:</para>
+        <programlisting># config/config.toml — one-time bootstrap seed
+[chirpstack]
+server_address = "chirpstack.example.com:8080"
+tenant_id = "&lt;your-tenant-uuid&gt;"
+
+[opcua]
+# Auto-generate a self-signed OPC UA keypair on first start.
+# Set this to false in production and provision your own keypair
+# (see "OPC UA encryption keys" below).
+create_sample_keypair = true
+# OPC UA listens on the standard port 4840 by default. To use a different
+# port, set host_port here and publish the same port in docker-compose.yml.</programlisting>
+        <para>You do <emphasis>not</emphasis> add applications, devices, or
+        metrics here — that is done in the web UI after first start. The
+        secrets stay in <filename>.env</filename>; do not put the API token or
+        password in this file.</para>
+      </section>
+
+      <section id="sec-install-keys">
+        <title>OPC UA encryption keys</title>
+        <para>OPC UA's signed and encrypted endpoints use a certificate and
+        private key (the gateway's "application instance certificate"), kept
+        in the <filename>pki/</filename> directory:</para>
+        <itemizedlist>
+          <listitem>
+            <para><filename>pki/own/</filename> — the gateway's own
+            certificate.</para>
+          </listitem>
+          <listitem>
+            <para><filename>pki/private/</filename> — the matching private
+            key. Must be tightly permissioned (see below).</para>
+          </listitem>
+          <listitem>
+            <para><filename>pki/trusted/</filename> — certificates of clients
+            the gateway accepts.</para>
+          </listitem>
+          <listitem>
+            <para><filename>pki/rejected/</filename> — certificates of clients
+            that have been refused. To trust a client, move its certificate
+            from here into <filename>trusted/</filename>.</para>
+          </listitem>
+        </itemizedlist>
+        <para><emphasis>Evaluation</emphasis> — set
+        <literal>create_sample_keypair = true</literal> (shown above) and the
+        gateway generates a self-signed keypair into
+        <filename>pki/own/</filename> and <filename>pki/private/</filename> on
+        first start.</para>
+
+        <para><emphasis>Production</emphasis> — set
+        <literal>create_sample_keypair = false</literal> and provision your own
+        keypair; the gateway refuses to start if the key is missing while the
+        option is off. The certificate must carry the gateway's application URI
+        (the <literal>[opcua].application_uri</literal> value, default
+        <literal>urn:chirpstack:opcua:gateway</literal>) in its
+        SubjectAltName — OPC UA requires this. Generate one with
+        <command>openssl</command>:</para>
+        <procedure>
+          <title>Generate a production keypair</title>
+          <step>
+            <para>Create the private key (PEM):</para>
+            <screen>openssl genrsa -out pki/private/private.pem 2048</screen>
+          </step>
+          <step>
+            <para>Create a self-signed certificate carrying the application
+            URI, valid here for five years (adjust the subject to your
+            organisation):</para>
+            <screen>openssl req -new -x509 -key pki/private/private.pem \
+  -out pki/own/cert.pem -days 1825 \
+  -subj "/CN=Chirpstack OPC UA Gateway/O=Your Organisation" \
+  -addext "subjectAltName=URI:urn:chirpstack:opcua:gateway"</screen>
+          </step>
+          <step>
+            <para>Convert the certificate to DER — the format opcgw loads
+            (<literal>[opcua].certificate_path</literal>,
+            <literal>own/cert.der</literal>):</para>
+            <screen>openssl x509 -in pki/own/cert.pem -outform der -out pki/own/cert.der</screen>
+          </step>
+          <step>
+            <para>Lock down the private key (the gateway refuses to start
+            otherwise):</para>
+            <screen>chmod 700 pki/private
+chmod 600 pki/private/private.pem</screen>
+          </step>
+        </procedure>
+        <para>The first time a client connects, its certificate lands in
+        <filename>pki/rejected/</filename>; move it to
+        <filename>pki/trusted/</filename> to allow that client.</para>
+      </section>
+
+      <section id="sec-install-start">
+        <title>Preparing directories and starting opcgw</title>
+        <para>The container runs as UID 10001 and cannot change ownership of
+        host files, so create the bind-mount directories and set their
+        ownership and the private-key permissions before the first
+        start:</para>
+        <screen>mkdir -p ./config ./log ./data
+mkdir -p ./pki/own ./pki/private ./pki/trusted ./pki/rejected
+chown -R 10001:10001 ./config ./pki ./log ./data
+chmod 700 ./pki/private</screen>
+        <para>Place your <filename>config/config.toml</filename> (previous
+        sections) in <filename>./config</filename>, then start the
+        gateway:</para>
+        <screen>docker compose up -d
+docker compose logs -f opcgw</screen>
+        <para>Leave the log tail running to watch the first ChirpStack poll
+        cycle complete.</para>
+      </section>
+
+      <section id="sec-install-verify">
+        <title>Verifying the installation</title>
+        <para>A successful start emits a sequence of structured log lines.
+        Confirm the gateway came up:</para>
+        <orderedlist>
+          <listitem>
+            <para>The OPC UA endpoint is listening:</para>
+            <screen>nc -z localhost 4840 &amp;&amp; echo "OPC UA endpoint reachable"</screen>
+          </listitem>
+          <listitem>
+            <para>The startup checkpoints are present (configuration loaded,
+            ChirpStack connected, OPC UA bound):</para>
+            <screen>docker compose logs opcgw 2&gt;&amp;1 | grep -E '(config_loaded|chirpstack_connect|opcua_limits_configured)'</screen>
+          </listitem>
+          <listitem>
+            <para>The first poll cycle has run (usually within ~30 s of
+            start):</para>
+            <screen>docker compose logs opcgw 2&gt;&amp;1 | grep 'poll_cycle_start'</screen>
+            <para>If nothing appears after ~30 s, see
+            <xref linkend="ch-troubleshooting"/>.</para>
+          </listitem>
+          <listitem>
+            <para>The container runs as the non-root user:</para>
+            <screen>docker exec opcgw id
+# Expected: uid=10001(opcgw) gid=10001(opcgw)</screen>
+          </listitem>
+          <listitem>
+            <para>The web UI is reachable and requires authentication —
+            browse to <literal>http://&lt;host&gt;:8080</literal>, which
+            should prompt for the user name (default
+            <literal>opcua-user</literal>) and the password from your
+            <filename>.env</filename>. This is where you continue with
+            <xref linkend="ch-configuration"/>.</para>
+          </listitem>
+        </orderedlist>
+        <important>
+          <para>The web UI is HTTP-only — its credentials travel in
+          cleartext. For anything beyond a trusted LAN, put a TLS-terminating
+          reverse proxy (nginx, Caddy, Traefik) in front of it. See
+          <xref linkend="sec-web-config"/>.</para>
+        </important>
+      </section>
+
+      <section id="sec-install-logging">
+        <title>Logging</title>
+        <para>Logging is set up once, at install time. The gateway writes
+        structured log lines (microsecond UTC timestamps,
+        <literal>key=value</literal> fields) to both the container's standard
+        error — visible via <command>docker compose logs</command> — and to
+        daily-rolling files in the <filename>log</filename> volume
+        (<filename>./log</filename> on the host). A root log plus per-area
+        files (ChirpStack, OPC UA, storage, configuration) are produced.</para>
+        <para>Set the verbosity with <literal>OPCGW_LOG_LEVEL</literal> in
+        <filename>.env</filename> — one of <literal>error</literal>,
+        <literal>warn</literal>, <literal>info</literal> (default),
+        <literal>debug</literal>, or <literal>trace</literal>:</para>
+        <programlisting>OPCGW_LOG_LEVEL=info</programlisting>
+        <para>The log files rotate daily; see
+        <xref linkend="sec-log-rotation"/> for retention and housekeeping.</para>
+      </section>
+
+      <section id="sec-install-stop">
+        <title>Stopping the gateway</title>
+        <para>Stop opcgw with <command>docker compose stop</command> (keep the
+        container) or <command>docker compose down</command> (remove it; your
+        data volume persists). Both send <literal>SIGTERM</literal>, which the
+        gateway shuts down on gracefully: it stops accepting new OPC UA
+        connections, lets the in-flight poll cycle finish so no metrics are
+        lost, checkpoints the database, and flushes the logs.</para>
+        <warning>
+          <title>Avoid force-killing</title>
+          <para>Do not use <literal>kill -9</literal> /
+          <literal>SIGKILL</literal>. The database is journaled and will
+          recover, but in-flight downlink commands may need manual inspection
+          and buffered log lines can be lost. Always prefer a graceful
+          stop.</para>
+        </warning>
+      </section>
+
+    </chapter>
+
+  <!-- ============================================ -->
+  <!-- CHAPTER: CONFIGURATION -->
+  <!-- ============================================ -->
+  <chapter id="ch-configuration">
+    <title>Configuration</title>
+
+      <section id="sec-config-overview">
+        <title>Configuration Overview</title>
+
+        <para>After the first boot, opcgw's configuration lives in its
+        SQLite database and is edited entirely from the web UI — you do
+        not hand-edit files for day-to-day changes.
+        <filename>config/config.toml</filename> is only a
+        <emphasis>first-boot seed</emphasis>: opcgw reads it once to
+        populate a fresh deployment, then SQLite becomes authoritative.
+        Secrets stay in a separate file and environment variables
+        override everything.</para>
+
+        <para>The configuration precedence ordering (highest priority
+        first) is:</para>
+        <orderedlist>
+          <listitem>
+            <para>Environment variables (<literal>OPCGW_</literal>
+            prefix) — always win. See
+            <xref linkend="app-env-reference"/>.</para>
+          </listitem>
+          <listitem>
+            <para>The SQLite database — the web-UI-editable runtime
+            config.</para>
+          </listitem>
+          <listitem>
+            <para><filename>config/secrets.toml</filename> — secret
+            fields only.</para>
+          </listitem>
+          <listitem>
+            <para><filename>config/config.toml</filename> — first-boot
+            seed (lowest priority above hard-coded defaults).</para>
+          </listitem>
+          <listitem>
+            <para>Built-in defaults.</para>
+          </listitem>
+        </orderedlist>
+
+        <para>The rest of this chapter follows the path an operator
+        actually takes: complete the <emphasis>first-run setup
+        wizard</emphasis>, then add applications, devices, and metrics
+        through the web UI <emphasis>pickers</emphasis>, and
+        periodically <emphasis>reconcile drift</emphasis> against
+        ChirpStack. A settings reference for each configuration section
+        follows the workflow, and
+        <xref linkend="sec-config-storage"/> explains how configuration
+        is stored and migrated.</para>
+      </section>
+
+      <section id="sec-first-run-wizard">
+        <title>First-run setup wizard</title>
+        <figure id="fig-setup-wizard">
+          <title>First-run setup wizard</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="../images/screenshot-setup-wizard.svg"
+                         format="SVG" width="80%" align="center"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+        <para>From a fresh installation — where
+        <filename>config/config.toml</filename> still carries the
+        placeholder ChirpStack token and an empty OPC UA password, and
+        the matching <literal>OPCGW_*</literal> environment variables are
+        unset — the gateway enters <emphasis>first-run mode</emphasis>.
+        Since Story F-2 (v2.2.x) the wizard collects
+        <emphasis>everything needed for first boot</emphasis>: the
+        ChirpStack connection <emphasis>and</emphasis> the OPC UA
+        password, so you never have to hand-edit a configuration file to
+        get a working gateway. The gateway is in first-run mode whenever
+        either secret is missing:</para>
+        <itemizedlist>
+          <listitem>
+            <para>The OPC UA server binds on its configured endpoint
+            but rejects every authentication attempt. External uptime
+            probes can confirm the gateway is alive, but no SCADA
+            client can connect until setup is complete.</para>
+          </listitem>
+          <listitem>
+            <para>The web UI redirects every request to
+            <filename>/setup</filename>, a one-shot setup form. The
+            wizard is the only reachable page until completion.</para>
+          </listitem>
+        </itemizedlist>
+
+        <procedure>
+          <title>Completing the wizard</title>
+          <step>
+            <para>Open the web UI in a browser; any URL redirects to
+            <filename>/setup</filename>.</para>
+          </step>
+          <step>
+            <para>Under <emphasis>ChirpStack connection</emphasis>, enter
+            the server address (a full URL such as
+            <literal>http://chirpstack:8080</literal>), the tenant ID,
+            and a ChirpStack API token with read access to the tenant's
+            applications and devices.</para>
+          </step>
+          <step>
+            <para>Under <emphasis>OPC UA server</emphasis>, enter a
+            password and confirmation. The password must be non-empty,
+            have no leading or trailing whitespace, not be a placeholder,
+            and the two fields must match. Submit the form.</para>
+          </step>
+          <step>
+            <para>On success the two secrets (the ChirpStack API token
+            and the OPC UA password) are saved to
+            <filename>config/secrets.toml</filename> (owner-only file
+            mode <literal>0600</literal>, gitignored) in a single atomic
+            write, the non-secret ChirpStack server address and tenant
+            are saved to the gateway database, and the gateway shuts down
+            gracefully.</para>
+          </step>
+          <step>
+            <para>Your supervisor (Docker restart policy or
+            <command>systemctl Restart=on-failure</command>) restarts
+            opcgw automatically. On the second boot it picks up the new
+            ChirpStack connection and password, login comes online, the
+            poller connects to ChirpStack, and the OPC UA server accepts
+            authenticated connections.</para>
+          </step>
+        </procedure>
+
+        <para><emphasis role="strong">What the wizard does not
+        touch.</emphasis> The web-UI login user and password and the
+        log-file location stay in <filename>.env</filename> by design —
+        the wizard never reads or writes them.</para>
+
+        <para><emphasis role="strong">One-shot semantics.</emphasis>
+        Once setup is complete, <filename>/setup</filename> is no longer
+        reachable. To rotate a secret later, either set
+        <literal>OPCGW_CHIRPSTACK__API_TOKEN</literal> /
+        <literal>OPCGW_OPCUA__USER_PASSWORD</literal> or edit
+        <filename>config/secrets.toml</filename> and restart.</para>
+
+        <para><emphasis role="strong">Trust model.</emphasis> Reach the
+        wizard only over a trusted operator network. For
+        public-internet deployments, set
+        <literal>OPCGW_OPCUA__USER_PASSWORD</literal> before the first
+        start to skip the wizard entirely.</para>
+
+        <para><emphasis role="strong">Wizard scope: password
+        only.</emphasis> The wizard collects only the login password.
+        Everything else (ChirpStack credentials, OPC UA endpoint and PKI
+        directory, login user name) must already be present in
+        <filename>config/config.toml</filename> or supplied via
+        <literal>OPCGW_*</literal> environment variables before the
+        gateway starts. The login user name defaults to
+        <literal>opcua-user</literal> if omitted. The recommended
+        starting point is the shipped
+        <filename>config/config.toml</filename>: copy it, fill in your
+        ChirpStack and admin credentials, and leave the password unset.
+        A fresh deployment with no applications configured boots fine —
+        you add applications, devices, and metrics from the web UI once
+        the wizard is done.</para>
+      </section>
+
+      <section id="sec-web-pickers">
+        <title>Adding applications, devices, and metrics via the web UI</title>
+        <figure id="fig-pickers">
+          <title>Name-driven inventory pickers</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="../images/screenshot-pickers.svg"
+                         format="SVG" width="80%" align="center"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+        <para>The
+        <filename>/applications.html</filename> and
+        <filename>/devices-config.html</filename> pages offer
+        <emphasis>name-driven pickers</emphasis> instead of the
+        legacy free-form UUID/DevEUI text inputs. The pickers are
+        populated from
+        <literal>GET /api/inventory/{applications,devices,uplinks}</literal>
+        — the operator never needs to copy a UUID from
+        ChirpStack into opcgw by hand.</para>
+
+        <para>The full add-flow is
+        <emphasis>application → device → metric</emphasis>:</para>
+
+        <orderedlist>
+          <listitem>
+            <para>On <filename>/applications.html</filename>, the
+            <emphasis>Create application</emphasis> form shows a
+            dropdown sourced from
+            <literal>/api/inventory/applications</literal>. Pick an
+            application by name; the hidden
+            <literal>application_id</literal> pre-fills and the
+            <literal>Application Name</literal> field defaults to the
+            ChirpStack name (operator-editable). Submit lands the
+            application in <filename>config/config.toml</filename>
+            through the existing CRUD path.</para>
+          </listitem>
+          <listitem>
+            <para>On <filename>/devices-config.html</filename>, each
+            already-configured application has an
+            <emphasis>Add device</emphasis> sub-form. The dropdown
+            fetches
+            <literal>/api/inventory/devices?application_id=&lt;id&gt;</literal>
+            and lets the operator pick a device by name. The DevEUI
+            is shown beneath the picker as a small read-only
+            footnote so the operator can copy it for ChirpStack-side
+            troubleshooting if needed.</para>
+          </listitem>
+          <listitem>
+            <para>The metric-picker sub-form is fed by
+            <literal>/api/inventory/uplinks?dev_eui=&lt;eui&gt;&amp;limit=10</literal>
+            and renders the
+            <literal>observed_keys</literal> aggregate as a
+            multi-select checkbox list. Each row carries an
+            auto-inferred wire-type
+            (<literal>Float | Int | Bool | String</literal>) which
+            the operator can override per row. Tick any combination
+            of keys to add them as metrics in one submission.</para>
+          </listitem>
+        </orderedlist>
+
+        <para><emphasis role="strong">Manual-entry fallback (load-bearing).</emphasis>
+        Every picker carries a
+        <emphasis>Switch to manual entry</emphasis> toggle. The toggle
+        also fires automatically when ChirpStack is unreachable, so the
+        operator never gets trapped. The chosen mode is remembered per
+        page in the browser, so an operator who prefers manual entry
+        does not have to re-toggle on every page load.</para>
+
+        <para>Three failure modes are covered:</para>
+        <itemizedlist>
+          <listitem>
+            <para><emphasis>ChirpStack maintenance window</emphasis> —
+            picker auto-fallbacks; operator can still configure opcgw
+            using values they know.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Device not yet enrolled in ChirpStack</emphasis>
+            — picker shows an empty-state and flips to manual; the
+            operator can pre-create opcgw config so the device works
+            the moment its first uplink lands.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Metric not yet emitted by the codec</emphasis>
+            — the uplink picker shows
+            <emphasis>no recent uplinks</emphasis> and falls back to
+            manual metric-row entry so the operator can hand-type a
+            metric_name they know the codec will eventually
+            produce.</para>
+          </listitem>
+        </itemizedlist>
+
+        <para><emphasis role="strong">Re-fetch on demand.</emphasis>
+        Each picker has a small <literal>↻</literal> refresh icon that
+        re-queries ChirpStack, bypassing the short-lived inventory
+        cache. Useful when you added a device to ChirpStack in another
+        tab and want to see it in opcgw immediately.</para>
+
+        <para>Picker activity (opens, manual fallbacks, and the
+        inferred metric type when you add a metric) is recorded in the
+        audit log; see <xref linkend="app-audit-events"/>.</para>
+      </section>
+
+      <section id="sec-inventory-drift">
+        <title>Reconciling drift between opcgw and ChirpStack</title>
+        <figure id="fig-drift">
+          <title>Inventory drift view</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="../images/screenshot-drift.svg"
+                         format="SVG" width="80%" align="center"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+        <para>The
+        <filename>/inventory-drift.html</filename> page compares
+        opcgw's configured applications, devices, and metrics against
+        ChirpStack's current inventory and highlights stale, missing,
+        available, and renamed resources. It covers what happens when the
+        ChirpStack-side inventory changes after opcgw has been
+        configured.</para>
+
+        <para>Every resource is classified into one of four buckets:</para>
+
+        <itemizedlist>
+          <listitem><para><literal>ok</literal> — present in both opcgw
+          and ChirpStack, names match. Information only; no action
+          needed.</para></listitem>
+          <listitem><para><literal>stale</literal> — configured in
+          opcgw, no longer in ChirpStack (or, for metrics, not seen in
+          the last 10 uplinks). Operator can <emphasis>Remove from
+          opcgw</emphasis> or <emphasis>Keep as alias</emphasis>.
+          Soft-stale metrics (codec emits the key conditionally) are
+          rendered in a softer yellow tone vs hard-stale red.</para></listitem>
+          <listitem><para><literal>available</literal> — present in
+          ChirpStack, not in opcgw. <emphasis>Add to opcgw</emphasis>
+          deep-links to the picker page with the chosen resource
+          pre-selected.</para></listitem>
+          <listitem><para><literal>drifted</literal> — present in both
+          but names (applications/devices) or wire types (metrics) do
+          not match. <emphasis>Update opcgw name to ChirpStack's</emphasis>
+          or <emphasis>Keep opcgw alias</emphasis>.</para></listitem>
+        </itemizedlist>
+
+        <note>
+          <title>No background polling</title>
+          <para>The drift view is operator-triggered only — opcgw does
+          not periodically compute drift. Every page load (and
+          <emphasis>Refresh now</emphasis> click) forces a fresh fetch
+          from ChirpStack (<literal>?refresh=true</literal>), bypassing
+          the inventory cache. This bounds the ChirpStack-side load
+          to active reconciliation sessions.</para>
+        </note>
+
+        <para>Typical scenarios:</para>
+
+        <variablelist>
+          <varlistentry>
+            <term>Device retired in ChirpStack</term>
+            <listitem><para>The device shows as
+            <literal>stale</literal>. <emphasis>Remove from
+            opcgw</emphasis> deletes the device + its metric mappings
+            (cascade scope shown in the confirmation modal).
+            ChirpStack-side resources are untouched.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>New device enrolled in ChirpStack</term>
+            <listitem><para>The device shows as
+            <literal>available</literal>. <emphasis>Add to
+            opcgw</emphasis> deep-links to
+            <filename>/devices-config.html</filename> with the device
+            picker pre-selected; the operator picks metrics from the
+            recent-uplinks list and saves.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Application renamed in ChirpStack</term>
+            <listitem><para>The application shows as
+            <literal>drifted</literal> with both names visible.
+            <emphasis>Update opcgw name to ChirpStack's</emphasis> issues
+            a <literal>PUT /api/applications/&lt;id&gt;</literal> with
+            the new name; <emphasis>Keep opcgw alias</emphasis> emits a
+            <literal>drift_dismissed</literal> audit event so the
+            deliberate choice is traceable.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Codec firmware adds a metric key</term>
+            <listitem><para>The metric shows as
+            <literal>available</literal>. <emphasis>Add to opcgw</emphasis>
+            deep-links to the metric picker with the key pre-ticked.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Configured wire-type doesn't match observed uplinks</term>
+            <listitem><para>The metric shows as <literal>drifted</literal>
+            with <literal>drift_details.reason="wire_type_mismatch"</literal>.
+            The drift view links to the devices-config page so the
+            operator can edit the metric type via the canonical edit
+            flow.</para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        <para>When ChirpStack is unreachable, the page renders the
+        opcgw-side rows as <literal>ok</literal> placeholders, surfaces
+        a banner explaining the situation, and disables all destructive
+        action buttons + hides <emphasis>Add to opcgw</emphasis>
+        buttons. A <emphasis>Retry</emphasis> button next to the banner
+        re-fires the drift fetch.</para>
+
+        <para>Opening the drift view and each reconciliation action you
+        take — including a deliberate <emphasis>Keep as alias</emphasis>
+        decision — are recorded in the audit log; see
+        <xref linkend="app-audit-events"/>.</para>
+      </section>
+
+      <section id="sec-settings-reference">
+        <title>Settings reference</title>
+        <para>The settings below are the gateway's runtime configuration.
+        Normally you edit them from the web UI's configuration editor — that
+        is the supported way to change them, and the values live in the SQLite
+        database. The <filename>config.toml</filename> snippets shown for each
+        group are only the first-boot seed (and the key names you would use in
+        an <literal>OPCGW_</literal> environment-variable override; see
+        <xref linkend="app-env-reference"/>). The
+        <literal>[group]</literal> names below match those keys and the
+        editor's groups.</para>
+      </section>
+
+      <section id="sec-global-config">
+        <title>Global settings</title>
+        <para>The <literal>[global]</literal> group currently carries a
+        single flag:</para>
+        <programlisting language="ini">[global]
+# Verbose internal debug output (currently a no-op operationally;
+# reserved for future debug-only behaviours that should not depend on
+# the tracing log level).
+debug = true</programlisting>
+        <para>All log-related configuration lives under the dedicated
+        <literal>[logging]</literal> section described next.</para>
+      </section>
+
+      <section id="sec-logging-config">
+        <title>Logging</title>
+        <para>Logging is set up once at install time — the log
+        directory and verbosity level. See
+        <xref linkend="sec-install-logging"/> for setup and
+        <xref linkend="sec-logs-observability"/> for reading the logs in
+        day-to-day operation. The keys are summarised in
+        <xref linkend="app-config-reference"/> and
+        <xref linkend="app-env-reference"/>.</para>
+      </section>
+
+      <section id="sec-chirpstack-config">
+        <title>ChirpStack connection</title>
+        <programlisting language="ini">[chirpstack]
+# ChirpStack server address (gRPC endpoint, http:// or https://)
+server_address = "http://chirpstack.example.com:8080"
+
+# API token issued by ChirpStack. NEVER commit a real token to VCS;
+# use OPCGW_CHIRPSTACK__API_TOKEN at deploy time.
+api_token = "your_api_token_here"
+
+# Tenant UUID
+tenant_id = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+# Polling frequency in seconds (default: 10)
+polling_frequency = 10
+
+# Connection retries when ChirpStack is unreachable (default: 10)
+retry = 10
+
+# Delay (seconds) between two retries (default: 10)
+delay = 10
+
+# Page size for pagination in list APIs (default: 100, range 1-1000)
+list_page_size = 100
+
+# Route ALL devices' values through the uplink event stream (default: false).
+# See "How device values reach OPC UA" below.
+#stream_all_devices = false</programlisting>
+
+        <para><emphasis role="bold">How device values reach OPC
+        UA.</emphasis> opcgw has two value paths. The <emphasis>uplink
+        event stream</emphasis> delivers every decoded device report as it
+        happens: OPC UA shows the raw last-known value, stamped with the
+        device's own report time — no averaging or summing (trending is
+        your SCADA's job). The legacy <emphasis>metrics poll</emphasis>
+        instead asks ChirpStack for time-aggregated buckets every
+        <literal>polling_frequency</literal> seconds; averages and sums
+        corrupt discrete states (a valve status byte must read
+        <literal>195</literal>, not an average), so the poll is being
+        retired as a value source. Valve-class devices (any device whose
+        command has <literal>command_class = "valve"</literal>) always use
+        the stream. Set <literal>stream_all_devices = true</literal> to
+        route every device with read metrics through the stream — the
+        recommended setting. One caveat: fields that ChirpStack sources
+        outside the codec's uplink object (typically
+        <literal>batteryLevel</literal> from DevStatus) never appear on
+        the stream; if you map one, the log warns with
+        <literal>uplink_metric_never_seen</literal>. On startup or after a
+        reconnect, opcgw backfills the last value from the device's recent
+        event history, so OPC UA is not empty while waiting for the next
+        report.</para>
+
+        <warning>
+          <title>API Token Security</title>
+          <para>The <literal>api_token</literal> grants full ChirpStack
+          access. Do not commit production tokens. Override at deploy
+          time:</para>
+          <screen>export OPCGW_CHIRPSTACK__API_TOKEN="your_secret_token"</screen>
+          <para>The token is never written to log output (a security
+          regression test in the suite asserts this).</para>
+        </warning>
+      </section>
+
+      <section id="sec-opcua-config">
+        <title>OPC UA server</title>
+        <programlisting language="ini">[opcua]
+# Application identity (mandatory)
+application_name = "Chirpstack OPC UA Gateway"
+application_uri  = "urn:chirpstack:opcua:gateway"
+product_uri      = "urn:chirpstack:opcua:gateway"
+
+# Diagnostics output from the OPC UA stack itself.
+# REQUIRED true when [opcua].max_connections is set — the session-count
+# gauge and the at-limit warn both read async-opcua's CurrentSessionCount
+# diagnostics variable. Startup fail-fasts otherwise.
+diagnostics_enabled = true
+
+# Optional: TCP hello timeout (default 5 s)
+# hello_timeout = 10
+
+# Optional: bind address (default: first interface IP)
+# host_ip_address = "0.0.0.0"
+
+# Optional: TCP port (default 4840 for this project)
+# host_port = 4840
+
+# PKI configuration (relative paths are resolved under pki_dir).
+# create_sample_keypair = false is the production default.
+# Set to true ONLY for development self-signed keypair auto-generation.
+create_sample_keypair = false
+certificate_path      = "own/cert.der"
+private_key_path      = "private/private.pem"
+trust_client_cert     = true
+check_cert_time       = true
+pki_dir               = "./pki"
+
+# User authentication (single user — multi-user RBAC is out of scope).
+# The password placeholder in the shipped TOML is rejected at startup —
+# always inject via OPCGW_OPCUA__USER_PASSWORD env var.
+user_name     = "opcua-user"
+user_password = "REPLACE_ME_WITH_OPCGW_OPCUA__USER_PASSWORD_ENV_VAR"
+
+# Staleness threshold in seconds.
+# Metrics older than this return Uncertain in OPC UA;
+# older than 24 h return Bad. Default: 120 (2 x default polling_frequency).
+# Range: 1-86400. Override: OPCGW_OPCUA__STALE_THRESHOLD_SECONDS
+stale_threshold_seconds = 120
+
+# Maximum concurrent OPC UA sessions. New sessions beyond
+# this limit are rejected with BadTooManySessions. Existing sessions
+# unaffected. Default: 10. Range: 1-4096. Setting 0 or > 4096 fails
+# startup. Override: OPCGW_OPCUA__MAX_CONNECTIONS
+# max_connections = 10
+
+# Subscription / message-size limits. Optional; default to
+# async-opcua library defaults. Override: OPCGW_OPCUA__&lt;UPPER&gt;
+# max_subscriptions_per_session = 10    # range 1-1000
+# max_monitored_items_per_sub   = 1000  # range 1-100000
+# max_message_size              = 327675  # range 1-268435456 (≈ 256 MiB)
+# max_chunk_count               = 5     # range 1-4096
+
+# HistoryRead per-call response cap. Caps the number
+# of HistoryData rows returned per NodeId per HistoryRead call. SCADA
+# clients page via follow-up calls (manual paging). Default 10000 ≈
+# 28 h of poll data at 10 s polling. Range: 1-1000000.
+# max_history_data_results_per_node = 10000</programlisting>
+
+        <para>The gateway advertises <emphasis>three</emphasis> OPC UA
+        endpoints on the same TCP port. SCADA clients pick the
+        endpoint matching their security posture; the gateway accepts the
+        user-token credentials against any of the three.</para>
+
+        <table frame="all">
+          <title>OPC UA endpoint matrix</title>
+          <tgroup cols="4">
+            <thead>
+              <row>
+                <entry>Endpoint</entry>
+                <entry>Security policy</entry>
+                <entry>Security mode</entry>
+                <entry>Intended use</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry><literal>null</literal></entry>
+                <entry><literal>None</literal></entry>
+                <entry><literal>None</literal></entry>
+                <entry>Development / first-run smoke tests on trusted
+                LANs.</entry>
+              </row>
+              <row>
+                <entry><literal>basic256_sign</literal></entry>
+                <entry><literal>Basic256</literal></entry>
+                <entry><literal>Sign</literal></entry>
+                <entry>Signed, unencrypted traffic when LAN traffic must
+                remain inspectable.</entry>
+              </row>
+              <row>
+                <entry><literal>basic256_sign_encrypt</literal></entry>
+                <entry><literal>Basic256</literal></entry>
+                <entry><literal>SignAndEncrypt</literal></entry>
+                <entry><emphasis>Production default.</emphasis> Highest
+                security level the gateway advertises.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+
+        <para>The PKI directory layout
+        (<filename>pki/own/</filename>,
+        <filename>pki/private/</filename>,
+        <filename>pki/trusted/</filename>,
+        <filename>pki/rejected/</filename>) is documented in
+        <filename>docs/security.md § "OPC UA security endpoints and
+        authentication"</filename>.</para>
+
+        <variablelist>
+          <varlistentry>
+            <term>stale_threshold_seconds</term>
+            <listitem>
+              <para>Drives the OPC UA <literal>StatusCode</literal>
+              returned with each metric read. See
+              <xref linkend="sec-staleness-status-codes"/>. May also be
+              overridden per device (see
+              <xref linkend="sec-source-timestamp"/>).</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>create_sample_keypair</term>
+            <listitem>
+              <para>When <literal>true</literal>, opcgw auto-generates a
+              self-signed certificate on first start. <emphasis>Production
+              default is <literal>false</literal></emphasis> — provide
+              real CA-signed (or self-signed) certificates manually at
+              <filename>pki/own/cert.der</filename> and
+              <filename>pki/private/private.pem</filename>. Release
+              builds with <literal>create_sample_keypair = true</literal>
+              emit a startup warning.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>max_connections</term>
+            <listitem>
+              <para>Caps concurrent OPC UA sessions. New
+              sessions beyond the cap are rejected with
+              <literal>BadTooManySessions</literal>; existing sessions
+              unaffected. A misbehaving SCADA reconnect loop or a
+              deliberate session flood cannot exhaust file descriptors or
+              memory. Sized per
+              <literal>(N SCADA clients × sessions each) + 20%
+              headroom</literal>; values above 50 should prompt a
+              deployment review. Hard cap 4096 (fd-exhaustion guard).
+              Inspect utilisation via
+              <literal>event="opcua_session_count"</literal> info gauge
+              and at-limit rejections via
+              <literal>event="opcua_session_count_at_limit"</literal>
+              warns.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>max_subscriptions_per_session, max_monitored_items_per_sub, max_message_size, max_chunk_count</term>
+            <listitem>
+              <para>Subscription / message-size shaping knobs
+              fed into async-opcua's <literal>ServerBuilder</literal> at
+              startup. Defaults match async-opcua 0.17.1 library
+              defaults; uncomment only if a deployment scenario requires
+              tuning. Resolved values are echoed at startup as
+              <literal>event="opcua_limits_configured"</literal>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>max_history_data_results_per_node</term>
+            <listitem>
+              <para>Per-NodeId HistoryRead response cap.
+              SCADA clients exceeding the cap page via follow-up
+              calls (manual paging — continuation points are not yet
+              implemented; see
+              <filename>docs/security.md § "Historical data
+              access"</filename>).</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+
+        <warning>
+          <title>OPC UA Private-Key Permissions</title>
+          <para>opcgw enforces filesystem permissions on the OPC UA
+          private key at startup, fail-closed. The gateway
+          <emphasis>refuses to start</emphasis> if any
+          <filename>pki/private/*.pem</filename> file is not at mode
+          <literal>0o600</literal>, or if the parent
+          <filename>pki/private</filename> directory is not at mode
+          <literal>0o700</literal>. The error message includes the
+          observed mode and the <command>chmod</command> recipe. Operator
+          remediation:</para>
+          <screen>chmod 700 pki/private
+find ./pki/private -type f -name '*.pem' -exec chmod 600 {} +    # no-op on fresh install</screen>
+          <para>Silently running with a world-readable private key is
+          worse than refusing to start — this fail-closed behaviour is
+          intentional.</para>
+        </warning>
+
+        <warning>
+          <title>OPC UA Authentication Audit Trail</title>
+          <para>Every failed OPC UA authentication emits a structured
+          <literal>warn!</literal> event
+          (<literal>event="opcua_auth_failed"</literal>) in
+          <filename>log/opc_ua.log</filename>. The submitted username is
+          sanitised (control chars escaped, truncated to 64 chars); the
+          attempted password is <emphasis>never</emphasis> logged. Source
+          IP is correlated from async-opcua's
+          <literal>info!</literal>-level
+          <literal>"Accept new connection from ..."</literal> line by
+          timestamp — keep
+          <literal>OPCGW_LOG_LEVEL</literal> at <literal>info</literal>
+          or below to preserve the correlation, or rely on the per-module
+          <filename>opc_ua.log</filename> file appender (captures at
+          DEBUG independently).</para>
+        </warning>
+      </section>
+
+      <section id="sec-web-config">
+        <title>Web UI</title>
+        <para>opcgw ships an embedded Axum HTTP server gated by HTTP
+        Basic auth. <emphasis>Off by default</emphasis> — existing operators
+        upgrading from earlier releases see no behavioural change unless they
+        explicitly enable it. The credentials are
+        <emphasis>shared</emphasis> with the <literal>[opcua]</literal>
+        section (same <literal>user_name</literal> /
+        <literal>user_password</literal>); one rotation step covers both
+        surfaces.</para>
+
+        <para>All configuration and monitoring pages share a single
+        <emphasis>navigation bar</emphasis> across the top of the window
+        (Dashboard, Applications, Devices configuration, Live Metrics,
+        Commands, Inventory drift, Singleton config), so the web UI behaves as
+        one cohesive application. The current page is highlighted in the bar.
+        The web UI is built from plain HTML/CSS/JavaScript with no build step
+        or external framework — a deliberate choice that keeps the gateway
+        lightweight and auditable.</para>
+
+        <programlisting language="ini">[web]
+# Master switch — default false.
+# Override: OPCGW_WEB__ENABLED=true
+enabled = true
+
+# Listening port. Default 8080. Range 1024-65535 (privileged ports rejected).
+port = 8080
+
+# Bind address. Default "0.0.0.0" (all interfaces). Use "127.0.0.1" if a
+# reverse proxy on the same host fronts the gateway.
+bind_address = "0.0.0.0"
+
+# HTTP Basic auth realm string. Default "opcgw". Max 64 chars, ASCII,
+# no '"', no '\', no leading/trailing whitespace.
+auth_realm = "opcgw"
+
+# CSRF allow-list for state-changing routes (POST/PUT/DELETE).
+# Each entry must parse as scheme://host[:port] (no path/query/fragment).
+# When omitted, defaults to ["http://&lt;bind_address&gt;:&lt;port&gt;"].
+# allowed_origins = ["http://gateway.local:8080"]</programlisting>
+
+        <variablelist>
+          <varlistentry>
+            <term>GET /</term>
+            <listitem>
+              <para>Live status dashboard. Single-screen view
+              of ChirpStack connection state, last-poll timestamp,
+              cumulative error count, configured application + device
+              counts. Auto-refreshes every 10 s; mobile-responsive layout;
+              OS-driven dark mode. Underlying JSON shape at
+              <filename>GET /api/status</filename>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>GET /metrics.html</term>
+            <listitem>
+              <para>Live metric values page. Per-application / per-device
+              grid showing metric name,
+              <emphasis>typed</emphasis> value (Float / Int / Bool /
+              String — 2.0+), unit, last-updated timestamp, and a
+              staleness badge (Good / Uncertain / Bad / Missing). JSON
+              shape at <filename>GET /api/devices</filename>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>GET /api/health</term>
+            <listitem>
+              <para>Minimal smoke endpoint returning
+              <literal>{"status":"ok"}</literal>. Used by integration
+              tests and external monitoring probes.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>/api/applications/* — CRUD endpoints</term>
+            <listitem>
+              <para>POST / PUT / DELETE on the application, device, and
+              command resources. CSRF-protected via
+              <literal>[web].allowed_origins</literal>. Audit events:
+              <literal>application_*</literal> / <literal>device_*</literal>
+              / <literal>command_*</literal> +
+              <literal>*_crud_rejected</literal> on validation failure.
+              State-changing mutations also fire
+              <literal>topology_change_detected</literal> if the OPC UA
+              address space needs reshaping.</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+
+        <para><emphasis>When changes take effect — staged edits and
+        Apply.</emphasis> Every configuration edit you make through the web UI
+        — the application tree (applications, devices, metrics, commands)
+        <emphasis>and</emphasis> the singleton
+        <literal>[global]</literal> / <literal>[chirpstack]</literal> /
+        <literal>[opcua]</literal> / <literal>[web]</literal> sections — is
+        <emphasis>staged</emphasis>: it is saved to the database but does not
+        change the running gateway yet. A yellow <quote>Unapplied
+        configuration changes</quote> bar appears at the bottom of the page
+        whenever you have staged edits. When you are done editing, click
+        <emphasis>Apply changes</emphasis> in that bar. The gateway then
+        performs a single graceful <emphasis>in-process soft restart</emphasis>
+        that re-reads the whole configuration from the database and brings the
+        data-plane (ChirpStack poller, OPC UA server, uplink event stream,
+        command handling) back up on the new settings. The Docker container is
+        <emphasis>never</emphasis> restarted by Apply; OPC UA clients briefly
+        disconnect and reconnect once per Apply. Because Apply re-reads
+        everything, <emphasis>all</emphasis> settings now take effect this way
+        — including the network bindings, ports, PKI paths, and OPC UA session
+        limits that previously required a manual restart. The one exception is
+        the web-login credentials (the web server itself survives the soft
+        restart, so rotating <literal>user_name</literal> /
+        <literal>user_password</literal> still needs a full process restart). A
+        staged change that fails to load on Apply is non-disruptive: the
+        gateway keeps running the previous configuration and logs
+        <literal>apply_failed</literal>.</para>
+
+        <para><emphasis>Backing up &amp; restoring configuration (Story
+        F-4).</emphasis> The singleton-configuration page has a <emphasis>Back up
+        &amp; restore</emphasis> section. <emphasis>Export config</emphasis>
+        downloads the whole configuration — the four
+        <literal>[global]</literal> / <literal>[chirpstack]</literal> /
+        <literal>[opcua]</literal> / <literal>[web]</literal> sections plus the
+        application/device/metric/command tree — as a portable TOML file.
+        <emphasis role="strong">Secrets are never included</emphasis>: the
+        ChirpStack API token and the OPC UA password are stripped, so the file is
+        safe to keep in version control or share. <emphasis>Import
+        config</emphasis> uploads a previously exported file: opcgw validates it,
+        merges it over the running configuration (your instance keeps its own
+        secrets — an import never changes them), and <emphasis>stages</emphasis>
+        it. Click <emphasis>Apply changes</emphasis> to activate the imported
+        configuration (one soft restart, as above). Use this to back up a working
+        setup, version it, or reproduce it on another gateway — for example to
+        stand up a demo from a saved file.</para>
+
+        <warning>
+          <title>Web UI is HTTP-only — TLS via reverse proxy</title>
+          <para>opcgw binds an HTTP listener; credentials transit in
+          cleartext. Enable <literal>[web]</literal> only on trusted LANs.
+          For internet exposure or any path crossing an untrusted hop,
+          deploy a TLS-terminating reverse proxy (nginx, Caddy, Traefik)
+          in front of the gateway and set
+          <literal>bind_address = "127.0.0.1"</literal> so the listener
+          is loopback-only.</para>
+        </warning>
+      </section>
+
+      <section id="sec-command-delivery-config">
+        <title>Command delivery</title>
+        <programlisting language="ini">[command_delivery]
+# Polling interval for ChirpStack delivery confirmations (default 5 s)
+status_poll_interval_secs = 5
+
+# Maximum time to wait for ChirpStack to confirm a Sent command (default 60 s).
+# Commands still pending after this become Failed.
+confirmation_timeout_secs = 60
+
+# Frequency of the timeout-detection scan (default 10 s)
+timeout_check_interval_secs = 10
+
+# Retention period for completed commands (default 7 days).
+# Confirmed/Failed commands are purged after this window.
+history_retention_days = 7</programlisting>
+      </section>
+
+      <section id="sec-application-config">
+        <title>Applications, devices, and metrics (bootstrap seed)</title>
+
+        <important>
+          <title>Canonical write path: use the web UI, not the TOML file</title>
+          <para>The <literal>[[application]]</literal> tree
+          is stored in SQLite and managed exclusively via the embedded web
+          UI (<filename>/applications.html</filename> and
+          <filename>/devices-config.html</filename>). The TOML
+          <literal>[[application]]</literal> section is read
+          <emphasis>once</emphasis> on the first boot and migrated
+          into SQLite automatically. After migration, editing the TOML file
+          has no effect on the running configuration.</para>
+          <para>Use this section as a reference when writing an initial
+          bootstrap seed (to pre-populate SQLite on first boot) or when
+          restoring from a TOML backup. For day-to-day configuration
+          changes, use the web UI.</para>
+        </important>
+
+        <para>The <literal>[[application]]</literal> TOML schema matches the
+        internal <literal>ChirpStackApplications</literal> struct. Each block
+        declares one application (ChirpStack application UUID + human name)
+        and contains nested device and metric blocks.</para>
+
+        <programlisting language="ini">[[application]]
+application_id   = "ae2012c2-75a1-407d-98ab-1520fb511edf"
+application_name = "Arrosage"
+
+  [[application.device]]
+  device_name = "Niveau_citerne"
+  device_id   = "a840418371886840"            # DevEUI
+
+    [[application.device.read_metric]]
+    metric_name             = "Niveau_cit"     # OPC UA browse name
+    chirpstack_metric_name  = "Water_deep_cm"  # ChirpStack metric key
+    metric_type             = "Float"          # Bool | Int | Float | String
+    metric_unit             = "cm"             # optional, web-dashboard suffix
+
+  [[application.device]]
+  device_name = "Vanne01"
+  device_id   = "524d1e0a02243201"
+
+    [[application.device.read_metric]]
+    metric_name            = "Status_v01"
+    chirpstack_metric_name = "valveStatusCode"
+    metric_type            = "Int"
+
+    [[application.device.command]]
+    command_name      = "Open_close_valve01"
+    command_id        = 1
+    command_confirmed = true     # request ChirpStack delivery confirmation
+    command_port      = 10       # downlink fPort
+    command_class     = "valve"  # optional device-class binding (Epic E)</programlisting>
+
+        <itemizedlist>
+          <listitem>
+            <para><literal>application_id</literal> must match a real
+            ChirpStack application UUID — opcgw uses it to scope the
+            <literal>List</literal> calls.</para>
+          </listitem>
+          <listitem>
+            <para><literal>device_id</literal> must match the DevEUI of a
+            real device.</para>
+          </listitem>
+          <listitem>
+            <para>
+            <literal>[[application.device.read_metric]]</literal> declares
+            uplink metrics. The <literal>metric_type</literal> string drives
+            both the persisted variant in SQLite and the OPC UA
+            <literal>Variant</literal> projection:</para>
+          </listitem>
+        </itemizedlist>
+
+        <table frame="all">
+          <title>metric_type to OPC UA Variant mapping</title>
+          <tgroup cols="3">
+            <thead>
+              <row>
+                <entry>TOML <literal>metric_type</literal></entry>
+                <entry>Storage <literal>MetricType</literal></entry>
+                <entry>OPC UA <literal>Variant</literal></entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry><literal>"Float"</literal></entry>
+                <entry><literal>Float(f64)</literal></entry>
+                <entry><literal>Variant::Float(f32)</literal> — narrowed
+                at the OPC UA boundary; emits
+                <literal>event="metric_read" reason="narrowing_overflow"
+                | "narrowing_underflow"</literal> on lossy narrowing</entry>
+              </row>
+              <row>
+                <entry><literal>"Int"</literal></entry>
+                <entry><literal>Int(i64)</literal></entry>
+                <entry><literal>Variant::Int32(i32)</literal> when the
+                value fits in i32; <literal>Variant::Int64(i64)</literal>
+                otherwise (counters, large-magnitude metrics)</entry>
+              </row>
+              <row>
+                <entry><literal>"Bool"</literal></entry>
+                <entry><literal>Bool(bool)</literal></entry>
+                <entry><literal>Variant::Boolean(bool)</literal></entry>
+              </row>
+              <row>
+                <entry><literal>"String"</literal></entry>
+                <entry><literal>String(String)</literal></entry>
+                <entry><literal>Variant::String(UAString)</literal> —
+                UTF-8 preserved</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+
+        <itemizedlist>
+          <listitem>
+            <para><literal>metric_unit</literal> is an optional
+            human-readable unit string surfaced on the web dashboard as a
+            value suffix (e.g. <literal>34.2 %</literal>,
+            <literal>17.5 cm</literal>). Empty-string units coalesce to
+            no-suffix.</para>
+          </listitem>
+          <listitem>
+            <para>
+            <literal>[[application.device.command]]</literal> declares a
+            downlink command surface. OPC UA writes against the
+            corresponding node enqueue a downlink with the configured
+            <literal>command_id</literal> and <literal>command_port</literal>;
+            when <literal>command_confirmed = true</literal> the queue
+            tracks delivery state and times out per the
+            <literal>[command_delivery]</literal> settings.</para>
+          </listitem>
+          <listitem>
+            <para>The optional <literal>command_class</literal> binds the
+            command to a device class so opcgw can present a
+            model-independent command surface. When omitted, an OPC UA write
+            is delivered as raw payload bytes (the value is sent verbatim as a
+            single byte). When set to <literal>"valve"</literal>, opcgw maps
+            the canonical value <literal>1</literal> (open) /
+            <literal>0</literal> (close) to a semantic command object
+            (<literal>{"command":"open"}</literal> /
+            <literal>{"command":"close"}</literal>) that the ChirpStack
+            device-profile codec encodes into the model-specific wire bytes —
+            so every valve model looks identical on OPC UA. Binding a command
+            to a class also routes the device's <emphasis>values</emphasis>
+            through the uplink event stream (raw last-known value with the
+            device's report time — see the
+            <literal>[chirpstack]</literal> section), so the valve's status
+            fields always show the true reported state. (Adding new device
+            classes arrives in later Epic E stories; the class is settable
+            from the web command editor.)</para>
+          </listitem>
+        </itemizedlist>
+
+        <note>
+          <title>Uniqueness constraints (enforced by validator and SQLite schema)</title>
+          <para><literal>application_id</literal> must be unique across the
+          application list; <literal>device_id</literal> must be unique
+          within one application (the same DevEUI under different
+          applications is explicitly allowed); <literal>chirpstack_metric_name</literal>
+          and <literal>metric_name</literal> must be unique within one
+          device; <literal>command_id</literal> and
+          <literal>command_name</literal> must be unique within one device.
+          These constraints are enforced by both the
+          <literal>AppConfig::validate()</literal> function and
+          the SQLite composite primary keys (schema v009).</para>
+        </note>
+
+        <note>
+          <title>Audit-event Taxonomy</title>
+          <para>Configuration mutations via the web CRUD endpoints emit a
+          closed-enum audit-event taxonomy:
+          <literal>application_created</literal> /
+          <literal>application_updated</literal> /
+          <literal>application_deleted</literal>;
+          <literal>device_created</literal> /
+          <literal>device_updated</literal> /
+          <literal>device_deleted</literal>;
+          <literal>command_created</literal> /
+          <literal>command_updated</literal> /
+          <literal>command_deleted</literal>;
+          <literal>config_reload trigger="crud_write"</literal> after each
+          successful SQLite commit. See
+          <filename>docs/logging.md § "Audit and diagnostic events"</filename>
+          for the full reference.</para>
+        </note>
+      </section>
+
+      <section id="sec-config-storage">
+        <title>How configuration is stored and migrated</title>
+
+        <para>Non-secret configuration — the application tree
+        <emphasis>and</emphasis> the singleton sections
+        <literal>[global]</literal>, <literal>[chirpstack]</literal>,
+        <literal>[opcua]</literal>, and <literal>[web]</literal> — is
+        stored in the SQLite database
+        (<filename>data/opcgw.db</filename>, file mode
+        <literal>0o600</literal>). Edit the application tree on the web
+        CRUD pages and the singleton sections in the singleton-config
+        editor at <filename>/singleton-config.html</filename>; opcgw
+        reads SQLite on every boot.</para>
+
+        <para>Secrets — <literal>[chirpstack].api_token</literal> and
+        <literal>[opcua].user_password</literal> — stay in
+        <filename>config/secrets.toml</filename> (file mode
+        <literal>0o600</literal>, written by the first-run wizard). They
+        are deliberately never migrated to SQLite; the singleton editor
+        masks them and refuses to write them.</para>
+
+        <para><emphasis role="strong">First-boot migration.</emphasis>
+        On the first boot, opcgw reads
+        <filename>config/config.toml</filename> and migrates its
+        non-secret values into SQLite. After that, SQLite is
+        authoritative: hand-edits to a migrated key in
+        <filename>config.toml</filename> have no effect at runtime, and
+        opcgw logs a once-per-boot warning if
+        <filename>config.toml</filename> is still present alongside a
+        populated database.</para>
+
+        <note>
+          <title>SQLite file permissions</title>
+          <para>On fresh creation opcgw sets
+          <filename>data/opcgw.db</filename> to mode
+          <literal>0o600</literal>. Existing databases are not changed
+          retroactively; if the file is wider than
+          <literal>0o600</literal>, opcgw warns once per boot. Run
+          <command>chmod 0600 data/opcgw.db</command> on existing
+          deployments.</para>
+        </note>
+
+        <para>Recommended cleanup once the migration has run:</para>
+        <procedure>
+          <title>Decommissioning config.toml</title>
+          <step>
+            <para>Verify the database matches your intended
+            configuration:</para>
+            <screen>bash scripts/check-d0-migration.sh data/opcgw.db</screen>
+          </step>
+          <step>
+            <para>Optionally archive then remove the seed file:</para>
+            <screen>cp config/config.toml config/config.toml.bootstrap-archived
+rm config/config.toml</screen>
+          </step>
+          <step>
+            <para>Restart opcgw. With
+            <filename>config.toml</filename> absent, the unused-file
+            warning no longer fires and opcgw boots from SQLite +
+            <filename>secrets.toml</filename> alone.</para>
+          </step>
+        </procedure>
+
+        <para>To change a runtime setting afterwards, use the
+        singleton-config editor or an <literal>OPCGW_</literal>
+        environment-variable override — not a
+        <filename>config.toml</filename> hand-edit.</para>
+      </section>
+
+      <section id="sec-config-env-overrides">
+        <title>Environment Variable Overrides</title>
+        <para>Any configuration value can be overridden by an
+        environment variable, and environment variables always take
+        precedence over SQLite and the seed file. The convention is the
+        <literal>OPCGW_</literal> prefix with <literal>__</literal>
+        separating nested keys (for example
+        <literal>OPCGW_CHIRPSTACK__POLLING_FREQUENCY=30</literal>). Two
+        convenience aliases, <literal>OPCGW_LOG_DIR</literal> and
+        <literal>OPCGW_LOG_LEVEL</literal>, are read early during
+        startup so logging is configured before the rest of the config
+        loads. The full list of variables is in
+        <xref linkend="app-env-reference"/>.</para>
+      </section>
+
+    </chapter>
+
+  <!-- ============================================ -->
+  <!-- CHAPTER: DAILY OPERATION & MAINTENANCE -->
+  <!-- ============================================ -->
+  <chapter id="ch-operation">
+      <title>Daily Operation and Maintenance</title>
+
+      <section id="sec-monitoring-overview">
+        <title>What to Monitor</title>
+        <figure id="fig-dashboard">
+          <title>Web UI status dashboard</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="../images/screenshot-dashboard.svg"
+                         format="SVG" width="80%" align="center"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+        <para>The gateway exposes its own health through three channels.
+        For a typical production deployment:</para>
+        <itemizedlist>
+          <listitem>
+            <para><emphasis>Live health (OPC UA)</emphasis> — read the
+            <literal>Gateway</literal> folder via OPC UA from your SCADA
+            front-end. See <xref linkend="sec-gateway-folder"/>.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Live health (Web UI dashboard)</emphasis> — if
+            <literal>[web].enabled = true</literal>, browse to
+            <literal>http://&lt;gateway-host&gt;:&lt;web-port&gt;/</literal>.
+            The landing page (redesigned in Story F-3) leads with an
+            <emphasis>at-a-glance health verdict</emphasis> — a banner that
+            reads <emphasis>All systems operational</emphasis> or a specific
+            degraded reason (ChirpStack unreachable, poller stalled, an apply
+            that failed, devices going stale, or staged changes pending) — and
+            shows tiles for ChirpStack connection state, poller status (active
+            vs stalled, judged against the configured poll interval), last-poll
+            timestamp, cumulative error count, application / device counts, and
+            uptime, plus a device-data-freshness panel (how many devices are
+            fresh / stale / bad / never reported). The verdict and freshness
+            counts are computed in the browser from the gateway's existing
+            status surfaces — opcgw itself computes no new aggregates, and the
+            error figure is a cumulative count since startup (there is no
+            per-error history on this page; use the logs for that). The metrics
+            page at <literal>/metrics.html</literal> shows live typed values
+            plus a staleness badge (Good / Uncertain / Bad / Missing) per
+            metric. Both pages auto-refresh every 10 s and expose JSON shapes
+            at <filename>/api/status</filename> and
+            <filename>/api/devices</filename> for
+            <command>curl | jq</command> / Prometheus textfile
+            exporters.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Diagnostics</emphasis> — tail the per-module
+            log files or aggregate them through your log shipper. See
+            <xref linkend="sec-logs-observability"/>.</para>
+          </listitem>
+        </itemizedlist>
+      </section>
+
+      <section id="sec-gateway-folder">
+        <title>The Gateway Folder in OPC UA</title>
+        <para>Under the configured root, opcgw publishes a synthetic
+        <literal>Gateway</literal> folder containing three health
+        variables:</para>
+        <variablelist>
+          <varlistentry>
+            <term><literal>LastPollTimestamp</literal>
+            (<literal>String</literal>, RFC 3339)</term>
+            <listitem>
+              <para>Time of the last successful poll cycle. The value is
+              <literal>NULL</literal> (OPC UA <literal>Variant::Empty</literal>)
+              until the first cycle completes; reading it before that emits
+              a <literal>warn</literal> log line with
+              <literal>warning="no_data_yet"</literal>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>error_count</literal>
+            (<literal>Int32</literal>)</term>
+            <listitem>
+              <para>Cumulative per-cycle error count carried in the
+              persisted gateway status row. Saturates at
+              <literal>i32::MAX</literal>; a saturation read emits a
+              warning. Spikes between consecutive cycles
+              (<literal>delta &gt;= 5</literal>) emit
+              <literal>operation = "error_spike"</literal>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>chirpstack_available</literal>
+            (<literal>Boolean</literal>)</term>
+            <listitem>
+              <para><literal>true</literal> when the most recent poll cycle
+              succeeded for at least one device, <literal>false</literal>
+              otherwise. The first per-cycle ChirpStack failure also emits
+              <literal>operation = "chirpstack_outage"</literal>.</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+        <para>All three reads are subject to the same staleness logic as
+        regular metrics; under normal operation they return
+        <literal>Good</literal>.</para>
+      </section>
+
+      <section id="sec-staleness-status-codes">
+        <title>Stale-Data Status Codes</title>
+        <para>Every metric read returns a value plus an OPC UA
+        <literal>StatusCode</literal> derived from the metric's age relative
+        to <literal>[opcua].stale_threshold_seconds</literal>. The age is
+        measured from the <emphasis>device's report time</emphasis> (the
+        OPC UA <literal>source_timestamp</literal>), not from the moment
+        opcgw received the value:</para>
+        <table frame="all">
+          <title>Metric staleness mapping</title>
+          <tgroup cols="3">
+            <thead>
+              <row>
+                <entry>Age</entry>
+                <entry>StatusCode</entry>
+                <entry>Operator interpretation</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>≤ <literal>stale_threshold_seconds</literal></entry>
+                <entry><literal>Good</literal></entry>
+                <entry>Fresh, trustworthy reading</entry>
+              </row>
+              <row>
+                <entry>between threshold and 24 h</entry>
+                <entry><literal>Uncertain</literal></entry>
+                <entry>Last-known value still served, but stale</entry>
+              </row>
+              <row>
+                <entry>&gt; 24 h</entry>
+                <entry><literal>Bad</literal></entry>
+                <entry>Decisively stale; treat the value as suspect</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+        <para>The global threshold (default 120 s) is often too tight for
+        battery-powered LoRaWAN sensors that report every 15–20 minutes —
+        they would read <literal>Uncertain</literal> between two perfectly
+        normal reports. Set a per-device override in that case:
+        <literal>stale_threshold_seconds = 1800</literal> on the
+        <literal>[[application.device]]</literal> block (the device-level
+        value wins over <literal>[opcua].stale_threshold_seconds</literal>).
+        Pick roughly twice the device's report interval.</para>
+        <para>Transitions between status codes emit
+        <literal>operation = "staleness_transition"</literal>:
+        in-flight transitions at <literal>info</literal>, the cold-start
+        first observation at <literal>debug</literal> (so restarts of a
+        large stale fleet do not flood the alert pipeline). Metrics whose
+        age sits within ±5 s of the threshold also emit
+        <literal>operation = "staleness_boundary"</literal> at
+        <literal>debug</literal> for diagnosability.</para>
+      </section>
+
+      <section id="sec-source-timestamp">
+        <title>Source Timestamp Mode (Per Device)</title>
+        <para>By default opcgw stamps every served value's OPC UA
+        <literal>SourceTimestamp</literal> with the
+        <emphasis>device's own report time</emphasis> — the strict OPC UA
+        convention that a tag carries the instant its value was actually
+        produced. For a slow-cadence LoRaWAN device (say a 20-minute uplink
+        interval) that timestamp is legitimately several minutes old and does
+        not advance between uplinks.</para>
+        <para>Some SCADA clients — notably <emphasis>Ignition</emphasis> —
+        apply their own staleness overlay on top of the value: if the
+        <literal>SourceTimestamp</literal> is older than a client-side
+        window, they render the tag as <literal>Uncertain</literal> /
+        <emphasis>Stale</emphasis>, even though opcgw returned
+        <literal>Good</literal>. The result is that every slow device reads
+        Uncertain between uplinks in the client, and — importantly —
+        <emphasis>raising <literal>stale_threshold_seconds</literal> does not
+        fix it</emphasis>, because that knob only governs opcgw's own
+        <literal>StatusCode</literal>, not the client's timestamp
+        interpretation.</para>
+        <para>The per-device <literal>source_timestamp_server</literal> flag
+        resolves this. When set to <literal>true</literal>, opcgw stamps the
+        value with the gateway's current time
+        (<literal>now()</literal>, the same instant as the
+        <literal>ServerTimestamp</literal>) so the client always sees a fresh
+        source timestamp and keeps the tag <literal>Good</literal>. The
+        staleness <literal>StatusCode</literal> model above is
+        <emphasis>unaffected</emphasis>: a device that genuinely stops
+        reporting past its <literal>stale_threshold_seconds</literal> still
+        flips to <literal>Uncertain</literal>, so you do not lose dead-device
+        detection.</para>
+        <para>Set it in one of three ways:</para>
+        <itemizedlist>
+          <listitem>
+            <para><emphasis>Web UI</emphasis> — Config → select the device →
+            tick <emphasis>"Use server time as OPC UA source
+            timestamp"</emphasis>, then <emphasis>Apply changes</emphasis>.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>config.toml</emphasis> —
+            <literal>source_timestamp_server = true</literal> on the
+            device's <literal>[[application.device]]</literal> block.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis>Device CRUD API</emphasis> — the
+            <literal>source_timestamp_server</literal> boolean field on
+            <literal>POST</literal> /
+            <literal>PUT /api/applications/&lt;app&gt;/devices/&lt;dev&gt;</literal>.</para>
+          </listitem>
+        </itemizedlist>
+        <para>The default (<literal>false</literal>) preserves strict OPC UA
+        semantics for every existing device; enable the flag only for the
+        devices whose client marks them stale.</para>
+      </section>
+
+      <section id="sec-monitoring-metrics">
+        <title>Operational KPIs</title>
+        <variablelist>
+          <varlistentry>
+            <term>Poll latency</term>
+            <listitem>
+              <para>Time to complete a full metric poll cycle. Should remain
+              below <literal>polling_frequency</literal>. Watch the per-cycle
+              duration in the
+              <literal>operation = "poll_cycle_end"</literal> log line
+              and the budget warning if
+              <literal>operation = "batch_write"</literal> exceeds
+              500 ms.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Connected devices</term>
+            <listitem>
+              <para>Devices producing successful reads in the most recent
+              cycle. The
+              <literal>device_polled success=true</literal> count tells you
+              the live fleet; a sudden drop is a signal to investigate
+              ChirpStack or radio coverage.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Database size</term>
+            <listitem>
+              <para>SQLite database file size growth. The pruner enforces
+              the historical retention window — if the database is growing
+              faster than expected, check the
+              <literal>operation = "prune_metric_history"</literal>
+              line.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>OPC UA read latency</term>
+            <listitem>
+              <para>Per-read budget is 100 ms. The gateway emits a
+              <literal>warn</literal> with
+              <literal>exceeded_budget = true</literal> on any read past
+              that bound; the microbench measured p95 around
+              11 µs at 1 kHz read rate, so budget exceedance is a strong
+              signal of contention.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Storage query latency</term>
+            <listitem>
+              <para>Per-query budget is 10 ms. Persistent
+              <literal>SQLITE_BUSY</literal> warnings indicate write
+              contention or pool sizing problems.</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+
+      <section id="sec-command-monitoring">
+        <title>Command Queue Monitoring</title>
+        <para>Downlink commands traverse three states:</para>
+        <orderedlist>
+          <listitem>
+            <para><literal>Pending</literal> — Enqueued by an OPC UA
+            write; not yet sent to ChirpStack.</para>
+          </listitem>
+          <listitem>
+            <para><literal>Sent</literal> — ChirpStack accepted the
+            downlink. If <literal>command_confirmed = true</literal>, the
+            gateway polls for confirmation every
+            <literal>status_poll_interval_secs</literal>.</para>
+          </listitem>
+          <listitem>
+            <para><literal>Confirmed</literal> /
+            <literal>Failed</literal> — Terminal states. A
+            <literal>Sent</literal> command that does not transition within
+            <literal>confirmation_timeout_secs</literal> becomes
+            <literal>Failed</literal>.</para>
+          </listitem>
+        </orderedlist>
+        <para>Use the SQLite database to inspect queue state directly
+        when needed:</para>
+        <screen>sqlite3 data/opcgw.db \
+  "SELECT command_id, status, created_at, sent_at, confirmed_at, error_message
+   FROM commands ORDER BY created_at DESC LIMIT 20;"</screen>
+      </section>
+
+      <section id="sec-logs-observability">
+        <title>Logs and observability</title>
+        <para>Logging is configured once at install time (see
+        <xref linkend="sec-install-logging"/>). This section covers the
+        day-to-day reading of those logs.</para>
+
+        <para>Every log line is structured — a free-text message plus
+        <literal>key=value</literal> fields and a microsecond UTC
+        timestamp — so the logs are easy to filter with
+        <command>grep</command> or feed into a log shipper.</para>
+
+        <para><emphasis role="strong">Where the logs live.</emphasis>
+        The gateway writes to the container's standard error (visible via
+        <command>docker compose logs</command>) and to daily-rolling files
+        in the log directory (<filename>./log</filename> by default). A
+        root file captures everything; four per-area files isolate one
+        subsystem each:</para>
+        <itemizedlist>
+          <listitem><para><filename>opc_ua_gw.log</filename> — the root
+          file (everything, at the configured level).</para></listitem>
+          <listitem><para><filename>chirpstack.log</filename> — ChirpStack
+          polling and connection.</para></listitem>
+          <listitem><para><filename>opc_ua.log</filename> — the OPC UA
+          server.</para></listitem>
+          <listitem><para><filename>storage.log</filename> — the SQLite
+          storage layer.</para></listitem>
+          <listitem><para><filename>config.log</filename> — configuration
+          loading and reload.</para></listitem>
+        </itemizedlist>
+        <para>The per-area files always capture full detail regardless of
+        the configured console level, so even when the console is quiet at
+        <literal>error</literal> you still have a complete per-subsystem
+        trace to investigate after the fact.</para>
+
+        <para><emphasis role="strong">Correlation id for reads.</emphasis>
+        Every OPC UA read carries a unique <literal>request_id</literal>,
+        and all log lines emitted while serving that read — including the
+        storage query and the staleness check — share it. To follow a
+        single client read end-to-end (at <literal>debug</literal> or
+        lower):</para>
+        <screen>grep request_id=&lt;uuid&gt; opc_ua_gw.log</screen>
+
+        <para><emphasis role="strong">Performance-budget
+        warnings.</emphasis> Three hot paths log a
+        <literal>warn</literal> with <literal>exceeded_budget=true</literal>
+        when a single operation runs slower than its budget. In steady
+        state these stay silent; a sustained stream of them points to
+        contention worth investigating.</para>
+        <table frame="all">
+          <title>Performance budgets</title>
+          <tgroup cols="2">
+            <thead>
+              <row>
+                <entry>Operation</entry>
+                <entry>Budget (warns if exceeded)</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>OPC UA read</entry>
+                <entry>100 ms per read</entry>
+              </row>
+              <row>
+                <entry>Storage query</entry>
+                <entry>10 ms per query</entry>
+              </row>
+              <row>
+                <entry>Metric batch write</entry>
+                <entry>500 ms per batch flush</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+
+        <para>Audit-relevant and diagnostic log lines carry an
+        <literal>event=</literal> field for easy filtering
+        (<command>grep 'event="..."' log/*.log</command>); the routine
+        operational lines carry an <literal>operation=</literal> field.
+        The full catalogues are in
+        <xref linkend="app-operation-names"/> and
+        <xref linkend="app-audit-events"/>.</para>
+      </section>
+
+      <section id="sec-database-maintenance">
+        <title>Database maintenance</title>
+        <para>SQLite is largely self-maintaining under WAL mode. Two
+        operations are worth scheduling.</para>
+
+        <procedure>
+          <title>Optimise (online, low-impact)</title>
+          <step>
+            <para>Without stopping the gateway, run:</para>
+            <screen>sqlite3 data/opcgw.db "PRAGMA optimize;"</screen>
+          </step>
+          <step>
+            <para>This refreshes query-planner statistics and completes in
+            milliseconds on a production-sized database.</para>
+          </step>
+        </procedure>
+
+        <procedure>
+          <title>Integrity check (offline)</title>
+          <step>
+            <para>Stop opcgw gracefully (<literal>SIGTERM</literal>).</para>
+          </step>
+          <step>
+            <para>Run the check — expected output is
+            <literal>ok</literal>:</para>
+            <screen>sqlite3 data/opcgw.db "PRAGMA integrity_check;"</screen>
+          </step>
+          <step>
+            <para>Restart opcgw.</para>
+          </step>
+        </procedure>
+      </section>
+
+      <section id="sec-historical-data-pruning">
+        <title>Historical metric pruning</title>
+        <para>The metric-history store grows with poll volume. A
+        background pruner automatically deletes readings older than the
+        configured retention window, so no operator action is normally
+        required. Pruning activity is logged with
+        <literal>operation = "prune_metric_history"</literal>, including
+        the cutoff time and the number of rows deleted.</para>
+        <para>There is no explicit "off" switch. To keep history
+        effectively forever, set the retention window longer than your
+        operational horizon.</para>
+      </section>
+
+      <section id="sec-command-history-pruning">
+        <title>Command history retention</title>
+        <para>Completed downlink commands
+        (<literal>Confirmed</literal> or <literal>Failed</literal>) are
+        retained for
+        <literal>[command_delivery].history_retention_days</literal>
+        (default 7 days), then purged automatically by the same background
+        pruner.</para>
+      </section>
+
+      <section id="sec-log-rotation">
+        <title>Log rotation</title>
+        <para>All log files are daily-rolling: at UTC midnight a new file
+        is started with a date suffix. opcgw does not delete old log files
+        — manage retention with your platform's standard tooling
+        (<literal>logrotate</literal>, <literal>journald</literal>,
+        Docker's logging driver, or a cron job).</para>
+      </section>
+    </chapter>
+
+  <!-- ============================================ -->
+  <!-- CHAPTER: TROUBLESHOOTING -->
+  <!-- ============================================ -->
+  <chapter id="ch-troubleshooting">
+    <title>Troubleshooting</title>
+
+      <section id="sec-symptom-cookbook">
+        <title>Symptom Cookbook</title>
+        <para>Each subsection below pairs a symptom an operator can observe
+        with the structured log lines that diagnose it and the
+        corrective action.</para>
+
+        <section id="sec-issue-chirpstack-connection">
+          <title>Cannot connect to ChirpStack</title>
+          <para><emphasis>Log signature:</emphasis>
+          <literal>operation="chirpstack_connect"</literal> with
+          <literal>success=false</literal>, repeated; or a single
+          <literal>operation="chirpstack_outage"</literal> on the first
+          per-cycle failure.</para>
+          <orderedlist>
+            <listitem>
+              <para>Confirm the configured
+              <literal>server_address</literal> resolves and the gRPC port
+              is reachable:
+              <command>nc -vz chirpstack.example.com 8080</command>.</para>
+            </listitem>
+            <listitem>
+              <para>Validate the API token. A 16/Unauthenticated tonic code
+              would surface as a generic
+              <literal>OpcGwError::ChirpStack(...)</literal>; cross-check by
+              hitting ChirpStack directly with
+              <command>grpcurl -H "Authorization: Bearer $TOKEN" \
+chirpstack:8080 list</command>.</para>
+            </listitem>
+            <listitem>
+              <para>Inspect <literal>last_successful_poll</literal> in the
+              <literal>chirpstack_outage</literal> warn line: a long gap
+              indicates a sustained outage. A future release will introduce
+              automatic reconnection; until then, the poller continues
+              attempting on its normal cadence.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-duplicate-rejected">
+          <title>Attempted to add a duplicate</title>
+          <para><emphasis>Log signature:</emphasis>
+          <literal>event="application_crud_rejected"</literal> or
+          <literal>event="device_crud_rejected"</literal> or
+          <literal>event="command_crud_rejected"</literal>, each carrying
+          <literal>reason="conflict" conflict_kind="duplicate"</literal>.
+          For a hot-reload (operator hand-edited
+          <filename>config/config.toml</filename> and saved):
+          <literal>event="config_reload_rejected" reason="conflict"
+          conflict_kind="duplicate"</literal>.</para>
+          <para>opcgw rejects same-level duplicates server-side: two
+          applications with the same <literal>application_id</literal>;
+          two devices with the same <literal>device_id</literal> under
+          one application; two metrics with the same
+          <literal>metric_name</literal> or
+          <literal>chirpstack_metric_name</literal> within one device;
+          two commands with the same <literal>command_id</literal> or
+          <literal>command_name</literal> within one device.</para>
+          <orderedlist>
+            <listitem>
+              <para>Find the rejection in the structured log:
+              <command>grep 'conflict_kind="duplicate"' opcgw.log</command>.
+              The <literal>field</literal> + <literal>value</literal> +
+              <literal>scope</literal> fields name exactly what was
+              rejected and at which level.</para>
+            </listitem>
+            <listitem>
+              <para>For an HTTP rejection (web UI / API), the 409
+              response body has the same shape:
+              <literal>{"error":"duplicate","field":"...","value":"...","scope":"...","hint":"..."}</literal>.
+              The UI surfaces the <literal>hint</literal> inline near
+              the offending input — pick a different identifier, or
+              DELETE the existing entry first.</para>
+            </listitem>
+            <listitem>
+              <para>For a <literal>config_reload_rejected</literal>
+              (TOML hand-edit), the in-memory configuration is
+              unchanged (no partial apply); the on-disk
+              <filename>config.toml</filename> is also untouched (the
+              gateway does not rewrite operator files). Hand-edit the
+              TOML to fix the duplicate, save the file, and re-trigger
+              the reload (SIGHUP).</para>
+            </listitem>
+            <listitem>
+              <para>Two patterns are explicitly NOT duplicates and
+              remain allowed: the same DevEUI under different
+              applications (one physical sensor exposed under multiple
+              OPC UA namespaces); the same
+              <literal>chirpstack_metric_name</literal> on different
+              devices (multiple sensors of the same kind).</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-error-spike">
+          <title>Sudden burst of errors</title>
+          <para><emphasis>Log signature:</emphasis>
+          <literal>operation="error_spike"</literal> with
+          <literal>delta &gt;= 5</literal>.</para>
+          <orderedlist>
+            <listitem>
+              <para>Cross-reference the surrounding
+              <literal>device_poll</literal> warns to identify the affected
+              devices.</para>
+            </listitem>
+            <listitem>
+              <para>If a single fleet-wide gateway, check ChirpStack itself.
+              If a localised group, check the radio path
+              (<literal>rssi</literal>, <literal>snr</literal> in ChirpStack
+              UI).</para>
+            </listitem>
+            <listitem>
+              <para>The spike is informational only — it does not gate
+              further polling.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-sqlite-busy">
+          <title>SQLite busy / locked warnings</title>
+          <para><emphasis>Log signature:</emphasis>
+          <literal>operation="storage_query" error="SQLITE_BUSY"
+          sqlite_error_code=DatabaseBusy</literal> (or
+          <literal>DatabaseLocked</literal>).</para>
+          <orderedlist>
+            <listitem>
+              <para>The <literal>sqlite_error_code</literal> field
+              distinguishes <literal>DatabaseBusy</literal> (waiting on a
+              lock) from <literal>DatabaseLocked</literal> (cross-connection
+              write contention).</para>
+            </listitem>
+            <listitem>
+              <para>WAL mode and the per-task connection pool make rare
+              <literal>SQLITE_BUSY</literal> tolerable. Sustained busy
+              warnings under steady load suggest pool undersizing or a
+              long-running write — verify the
+              <literal>operation = "batch_write"</literal> latencies.</para>
+            </listitem>
+            <listitem>
+              <para>Run integrity check during a maintenance window:
+              <command>sqlite3 data/opcgw.db "PRAGMA integrity_check;"</command>.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-budget-exceeded">
+          <title>Performance budgets exceeded</title>
+          <para><emphasis>Log signature:</emphasis> any of
+          <literal>opc_ua_read</literal>,
+          <literal>storage_query</literal>, or
+          <literal>batch_write</literal> with
+          <literal>exceeded_budget=true</literal>.</para>
+          <orderedlist>
+            <listitem>
+              <para>Capture the <literal>request_id</literal> on an
+              <literal>opc_ua_read</literal> warn and grep the file logs for
+              the full read-path trace.</para>
+            </listitem>
+            <listitem>
+              <para>If the bottleneck is
+              <literal>storage_query</literal>, check
+              <literal>query_type</literal> and the
+              <literal>SQLITE_BUSY</literal> rate at the same time.</para>
+            </listitem>
+            <listitem>
+              <para>If <literal>batch_write</literal> is slow, the
+              cumulative per-cycle metric count
+              (<literal>metrics_count</literal>) plus disk I/O contention
+              are the usual culprits.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-no-data-yet">
+          <title>OPC UA client sees NULL <literal>LastPollTimestamp</literal></title>
+          <para><emphasis>Log signature:</emphasis>
+          <literal>operation="health_metric_read" metric="LastPollTimestamp"
+          warning="no_data_yet"</literal>; once-per-process
+          <literal>operation="gateway_status_init"</literal>.</para>
+          <orderedlist>
+            <listitem>
+              <para>This is normal during startup, before the first poll
+              cycle has completed. The gateway is healthy.</para>
+            </listitem>
+            <listitem>
+              <para>If it persists past one polling interval, the first
+              cycle is failing — see
+              <xref linkend="sec-issue-chirpstack-connection"/>.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-no-opc-clients">
+          <title>OPC UA clients cannot connect</title>
+          <orderedlist>
+            <listitem>
+              <para>Verify the OPC UA server bound successfully — search
+              the log for
+              <literal>event="opcua_limits_configured"</literal> (emitted once by <filename>src/opc_ua.rs</filename> after the OPC UA server applies its session / subscription / message-size limits) or the periodic <literal>event="opcua_session_count"</literal> gauge.</para>
+            </listitem>
+            <listitem>
+              <para>Confirm the port is listening:
+              <command>ss -tlnp sport = :4840</command> (or
+              <command>netstat -tlnp | grep 4840</command>).</para>
+            </listitem>
+            <listitem>
+              <para>Confirm the firewall permits inbound connections to
+              the configured port.</para>
+            </listitem>
+            <listitem>
+              <para>If PKI is enabled, confirm the client certificate is
+              under <filename>pki_dir/trusted/</filename>. Rejected
+              certificates land in <filename>pki_dir/rejected/</filename>;
+              copy them across explicitly to trust them.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-stale-metrics">
+          <title>OPC UA clients see Uncertain or Bad status</title>
+          <para><emphasis>Log signature:</emphasis>
+          <literal>operation="staleness_transition" status_code=Uncertain</literal>
+          (or <literal>Bad</literal>); possibly
+          <literal>operation="staleness_boundary"</literal> for metrics
+          flickering near the threshold.</para>
+          <orderedlist>
+            <listitem>
+              <para>Map the affected metric to its device and check that
+              the device is producing uplinks (ChirpStack UI).</para>
+            </listitem>
+            <listitem>
+              <para>Verify <literal>polling_frequency</literal> against
+              <literal>stale_threshold_seconds</literal>: the latter should
+              be at least 2× the former so transient missed cycles do not
+              flap the status.</para>
+            </listitem>
+            <listitem>
+              <para>For a fleet-wide
+              <literal>Uncertain</literal> wave that resolves on its own,
+              suspect a brief ChirpStack outage; cross-check
+              <literal>chirpstack_outage</literal> in the same time
+              window.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-database-corruption">
+          <title>Database integrity errors</title>
+          <para><emphasis>Log signature:</emphasis>
+          <literal>OpcGwError::Storage</literal> with messages mentioning
+          <literal>"disk image malformed"</literal>.</para>
+          <orderedlist>
+            <listitem>
+              <para>Stop the gateway gracefully
+              (<literal>SIGTERM</literal>) so the WAL is checkpointed.</para>
+            </listitem>
+            <listitem>
+              <para>Back up the database before any recovery action:
+              <command>cp -p data/opcgw.db data/opcgw.db.backup</command>.</para>
+            </listitem>
+            <listitem>
+              <para>Run the SQLite integrity check:
+              <command>sqlite3 data/opcgw.db "PRAGMA integrity_check;"</command>.
+              If it returns <literal>ok</literal>, the issue may have been
+              transient; restart the gateway.</para>
+            </listitem>
+            <listitem>
+              <para>If integrity is broken, the gateway will recreate the
+              schema on next start — but historical metrics are lost. Plan
+              backups accordingly.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-chirpstack-auth">
+          <title>ChirpStack authentication failure</title>
+          <para><emphasis>Symptom:</emphasis> The gateway never logs a
+          successful <literal>chirpstack_connect</literal> info line; OPC
+          UA reads return the discriminant string or
+          <literal>BadDataUnavailable</literal>; no
+          <literal>poll_cycle_end</literal> emissions.</para>
+          <para><emphasis>Diagnostic recipe:</emphasis></para>
+          <screen># systemd:
+journalctl -u opcgw | grep -E 'operation="chirpstack_connect".*(Unauthenticated|PermissionDenied|InvalidArgument)'
+
+# Docker:
+docker logs opcgw 2&gt;&amp;1 | grep -E 'operation="chirpstack_connect".*(Unauthenticated|PermissionDenied|InvalidArgument)'</screen>
+          <para><emphasis>Root cause:</emphasis> Most commonly an unset,
+          rotated, or wrong-tenant
+          <envar>OPCGW_CHIRPSTACK__API_TOKEN</envar>. The shipped
+          <filename>config/config.toml</filename> contains a placeholder
+          token; the gateway refuses to start with the placeholder in
+          place. ChirpStack returns gRPC code 16 / Unauthenticated when
+          the bearer token is invalid.</para>
+          <para><emphasis>Remediation:</emphasis></para>
+          <orderedlist>
+            <listitem>
+              <para>Confirm the env-var is set in the running
+              process:</para>
+              <screen># Docker:
+docker exec opcgw env | grep -c OPCGW_CHIRPSTACK__API_TOKEN
+# Expected: 1
+# systemd:
+sudo systemctl show opcgw -p Environment | grep -c OPCGW_CHIRPSTACK__API_TOKEN
+# Inspect the loaded env-file:
+sudo grep OPCGW_CHIRPSTACK__API_TOKEN /etc/opcgw/env</screen>
+            </listitem>
+            <listitem>
+              <para>Issue a fresh ChirpStack API token (ChirpStack v4 UI
+              → API Keys) scoped to the configured
+              <literal>[chirpstack].tenant_id</literal>. Verify
+              independently with
+              <command>grpcurl -H "Authorization: Bearer $TOKEN"
+              chirpstack:8080 list</command>.</para>
+            </listitem>
+            <listitem>
+              <para>Inject the new token via the env-var (NOT into
+              <filename>config.toml</filename>) and restart the gateway
+              (<command>systemctl restart opcgw</command> /
+              <command>docker compose up -d</command>).</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-opcua-connection-refused">
+          <title>OPC UA connection refused / BadTooManySessions</title>
+          <para><emphasis>Symptom:</emphasis> SCADA client cannot
+          establish a session; existing sessions continue working
+          (suggests the session cap), or all clients are refused
+          (suggests auth / endpoint mismatch).</para>
+          <para><emphasis>Diagnostic recipe:</emphasis></para>
+          <screen>journalctl -u opcgw | grep -E '(opcua_session_count_at_limit|opcua_auth_failed)'</screen>
+          <para><emphasis>Root cause:</emphasis></para>
+          <itemizedlist>
+            <listitem>
+              <para><literal>event="opcua_session_count_at_limit"</literal>
+              warns — the
+              <literal>[opcua].max_connections</literal> cap (default
+              10) is saturated; new
+              <literal>CreateSession</literal> attempts get
+              <literal>BadTooManySessions</literal>. Cross-reference the
+              <literal>source_ip</literal> field to identify a runaway
+              reconnect loop or a port-scan.</para>
+            </listitem>
+            <listitem>
+              <para><literal>event="opcua_auth_failed"</literal> warns —
+              user-token credentials don't match
+              <literal>[opcua].user_name</literal> /
+              <literal>[opcua].user_password</literal>. The
+              <literal>user</literal> field is sanitised; the attempted
+              password is never logged.</para>
+            </listitem>
+          </itemizedlist>
+          <para><emphasis>Remediation:</emphasis></para>
+          <orderedlist>
+            <listitem>
+              <para>For at-limit rejections: raise
+              <literal>[opcua].max_connections</literal> per the
+              tuning checklist in <xref linkend="sec-opcua-config"/>
+              (sized as <literal>N SCADA clients × sessions each + 20%
+              headroom</literal>), then SIGHUP — note that
+              <literal>max_connections</literal> is
+              <emphasis>restart-required</emphasis> per the
+              hot-reload taxonomy, so a full process restart is needed.
+              Investigate the offending
+              <literal>source_ip</literal> if the cap rejection is
+              unexpected.</para>
+            </listitem>
+            <listitem>
+              <para>For auth failures: rotate
+              <envar>OPCGW_OPCUA__USER_PASSWORD</envar>; verify the
+              SCADA client is configured with the matching credential;
+              confirm <literal>OPCGW_LOG_LEVEL</literal> is
+              <literal>info</literal> or below so the source-IP
+              correlation (<literal>"Accept new connection from
+              ..."</literal> line by async-opcua) survives.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-metric-parse-legacy">
+          <title>Polled metrics not appearing in OPC UA Read</title>
+          <para><emphasis>Symptom:</emphasis> SCADA client reads a metric
+          NodeId and receives <literal>BadDataUnavailable</literal>
+          (legacy-row symptom) or the discriminant string
+          <literal>"Float"</literal> /
+          <literal>"Int"</literal> (legacy symptom — should NOT occur
+          on v2.0 GA). Web dashboard shows the
+          <literal>Missing</literal> badge.</para>
+          <para><emphasis>Diagnostic recipe:</emphasis></para>
+          <screen>journalctl -u opcgw | grep 'event="metric_parse"'
+# Inspect the row directly:
+sqlite3 ./opcgw.db \
+  "SELECT device_id, metric_name, value_type, value_real, value_int, value_bool, value_text
+   FROM metric_values WHERE device_id='&lt;eui&gt;' AND metric_name='&lt;name&gt;';"</screen>
+          <para><emphasis>Root cause:</emphasis></para>
+          <itemizedlist>
+            <listitem>
+              <para><literal>value_type='legacy'</literal> rows surface
+              as <literal>BadDataUnavailable</literal> for ONE poll
+              interval after a Path-A migration (<xref
+              linkend="ch-upgrade"/>) until the next poll cycle UPSERTs
+              a typed payload.</para>
+            </listitem>
+            <listitem>
+              <para><literal>event="metric_parse"
+              reason="non_finite"</literal> or
+              <literal>reason="invalid_bool"</literal> or
+              <literal>reason="int_overflow"</literal> — the poller
+              skipped this metric for this cycle (the
+              NaN/Inf filter at the poller boundary). The metric is
+              skipped, not silently coerced.</para>
+            </listitem>
+            <listitem>
+              <para>If <literal>value_type</literal> is
+              <literal>real</literal> /
+              <literal>int</literal> / <literal>bool</literal> /
+              <literal>text</literal> but the corresponding typed column
+              is NULL: schema drift — investigate via
+              <command>PRAGMA quick_check;</command>.</para>
+            </listitem>
+          </itemizedlist>
+          <para><emphasis>Remediation:</emphasis></para>
+          <orderedlist>
+            <listitem>
+              <para>For legacy rows: wait one poll interval; the row
+              will be replaced with a typed payload on the next
+              successful poll. Persistent legacy rows past one interval
+              indicate the poller cannot reach the device — cross-check
+              <literal>device_polled success=true</literal>.</para>
+            </listitem>
+            <listitem>
+              <para>For <literal>reason="non_finite"</literal>:
+              investigate sensor calibration. For
+              <literal>reason="invalid_bool"</literal>: confirm device
+              firmware emits <literal>0.0</literal> or
+              <literal>1.0</literal>. For
+              <literal>reason="int_overflow"</literal>: the metric
+              exceeds i64 range — check device firmware emit
+              precision.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-historyread-empty">
+          <title>HistoryRead returns empty / BadDataUnavailable</title>
+          <para><emphasis>Symptom:</emphasis> SCADA client issues an OPC
+          UA <literal>HistoryRead</literal> over a 7-day window and gets
+          fewer rows than expected, or every row carries
+          <literal>StatusCode::BadDataUnavailable</literal>.</para>
+          <para><emphasis>Diagnostic recipe:</emphasis></para>
+          <screen>journalctl -u opcgw | grep 'event="metric_history_summary"' | tail -10
+journalctl -u opcgw | grep 'event="metric_history_read"' | tail -10</screen>
+          <para><emphasis>Root cause:</emphasis>
+          <literal>metric_history_summary</literal> (trace) is the
+          aggregate-skip telemetry per <literal>query_metric_history</literal>
+          call; it carries
+          <literal>schema_drift_skipped</literal> and
+          <literal>unparseable_timestamp_skipped</literal> counters.
+          Legacy rows in <literal>metric_history</literal> surface as
+          <literal>DataValue { value: None, status:
+          BadDataUnavailable }</literal> — they are NOT
+          silently dropped from the stream. Per-row narrowing failures
+          fire <literal>metric_history_read</literal> with
+          <literal>reason ∈ {narrowing_overflow,
+          narrowing_underflow}</literal>.</para>
+          <para><emphasis>Remediation:</emphasis></para>
+          <orderedlist>
+            <listitem>
+              <para>For legacy rows (<literal>BadDataUnavailable</literal>
+              in the response stream): expected during the 2.0 payload
+              migration window. New rows captured after upgrade carry
+              typed payloads.</para>
+            </listitem>
+            <listitem>
+              <para>For per-call cap saturation: check
+              <literal>[opcua].max_history_data_results_per_node</literal>
+              (default 10000 ≈ 28 h at 10 s polling). For longer
+              windows, SCADA clients must page via follow-up calls
+              (manual paging — continuation points are not implemented;
+              see <filename>docs/security.md § "Historical data
+              access"</filename>).</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-pki-permissions">
+          <title>Gateway refuses to start — PKI permissions</title>
+          <para><emphasis>Symptom:</emphasis> opcgw exits at startup with
+          an error message mentioning the private-key file mode or the
+          <filename>pki/private</filename> directory mode.</para>
+          <para><emphasis>Diagnostic recipe:</emphasis></para>
+          <screen>ls -la pki/private/
+# Expected:
+#   drwx------ ... pki/private
+#   -rw------- ... pki/private/private.pem</screen>
+          <para><emphasis>Root cause:</emphasis> opcgw enforces the
+          private-key permissions fail-closed at startup. The gateway
+          refuses to start unless
+          each <filename>pki/private/*.pem</filename> file is mode
+          <literal>0o600</literal> and the parent directory is mode
+          <literal>0o700</literal>. The error text includes the observed
+          mode and a <command>chmod</command> recipe.</para>
+          <para><emphasis>Remediation:</emphasis></para>
+          <orderedlist>
+            <listitem>
+              <para>Tighten the permissions per the error
+              message:</para>
+              <screen>chmod 700 pki/private
+find ./pki/private -type f -name '*.pem' -exec chmod 600 {} +    # no-op on fresh install</screen>
+            </listitem>
+            <listitem>
+              <para>For Docker / Compose deployments, the host-side
+              directory must be at the same modes — UID 10001 owns the
+              files and the gateway cannot <command>chmod</command>
+              loose modes (it can only validate them). Apply on the host
+              before <command>docker compose up</command>.</para>
+            </listitem>
+            <listitem>
+              <para>For an upgrade from older deployments (which
+              left <filename>private.pem</filename> at mode
+              <literal>0o644</literal>): run
+              <command>find pki/private -type f -name '*.pem' -exec
+              chmod 600 {} \;</command> then restart.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-web-auth-401">
+          <title>Web UI returns 401 / 404</title>
+          <para><emphasis>Symptom:</emphasis> Browser displays the
+          gateway URL's Basic-auth prompt repeatedly (401), or after a
+          successful auth shows a 404 on
+          <filename>/index.html</filename> or
+          <filename>/metrics.html</filename>.</para>
+          <para><emphasis>Diagnostic recipe:</emphasis></para>
+          <screen>journalctl -u opcgw | grep 'event="web_auth_failed"' | tail -10
+# Verify the web server actually started:
+journalctl -u opcgw | grep 'event="web_server_started"'</screen>
+          <para><emphasis>Root cause:</emphasis></para>
+          <itemizedlist>
+            <listitem>
+              <para>For 401: the <literal>web_auth_failed</literal> warn
+              carries a <literal>reason</literal> field
+              (<literal>missing</literal>,
+              <literal>malformed_scheme</literal>,
+              <literal>malformed_base64</literal>,
+              <literal>missing_colon</literal>,
+              <literal>user_mismatch</literal>,
+              <literal>password_mismatch</literal>). Web credentials are
+              <emphasis>shared</emphasis> with
+              <literal>[opcua].user_name</literal> /
+              <literal>[opcua].user_password</literal> — check the env
+              vars.</para>
+            </listitem>
+            <listitem>
+              <para>For 404: the embedded web server resolves
+              <filename>static/</filename> relative to the gateway's
+              CWD. For Docker the
+              <filename>Dockerfile</filename> copies
+              <filename>static/</filename> into
+              <filename>/usr/local/bin/static</filename>; for systemd
+              the unit file must set
+              <literal>WorkingDirectory=/var/lib/opcgw</literal> with
+              <filename>static/</filename> deployed there.</para>
+            </listitem>
+          </itemizedlist>
+          <para><emphasis>Remediation:</emphasis></para>
+          <orderedlist>
+            <listitem>
+              <para>Confirm env vars are set:</para>
+              <screen># Docker
+docker exec opcgw env | grep -E 'OPCGW_OPCUA__USER_NAME|OPCGW_OPCUA__USER_PASSWORD|OPCGW_WEB_'
+# systemd
+sudo grep -E 'OPCGW_OPCUA__USER_NAME|OPCGW_OPCUA__USER_PASSWORD|OPCGW_WEB_' /etc/opcgw/env</screen>
+            </listitem>
+            <listitem>
+              <para>Confirm <literal>[web].enabled = true</literal> (or
+              <envar>OPCGW_WEB__ENABLED=true</envar>) and that
+              <literal>event="web_server_started"</literal> appears
+              within ~5 s of startup. Absence of that line means the
+              web server is disabled.</para>
+            </listitem>
+            <listitem>
+              <para>For 404: verify
+              <filename>static/index.html</filename>,
+              <filename>static/metrics.html</filename>, and the
+              JavaScript files are present in the CWD-relative
+              <filename>static/</filename> directory.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+
+        <section id="sec-issue-log-growth">
+          <title>Log files growing too fast</title>
+          <para><emphasis>Symptom:</emphasis> The
+          <literal>[logging].dir</literal> directory grows by hundreds
+          of MB per day, eventually saturating local disk.</para>
+          <para><emphasis>Diagnostic recipe:</emphasis></para>
+          <screen>du -sh log/
+ls -laS log/ | head -20</screen>
+          <para><emphasis>Root cause:</emphasis> opcgw uses
+          daily-rolling file appenders (one root +
+          four per-module). The per-module files always capture at
+          <literal>TRACE</literal> independently of the global level —
+          this is deliberate (forensic detail when the console is
+          intentionally quiet). Volume scales with poll cadence and OPC
+          UA read rate; 10 devices at 1 Hz polling under a SCADA client
+          actively subscribing typically produces 50-200 MB/day.</para>
+          <para><emphasis>Remediation:</emphasis></para>
+          <orderedlist>
+            <listitem>
+              <para>Configure your platform's log-retention tooling
+              (<command>logrotate</command>, <command>journald</command>
+              with <literal>SystemMaxUse=</literal>, Docker's
+              <literal>--log-opt max-size=</literal>) — opcgw itself
+              does not delete old daily-rolled files.</para>
+            </listitem>
+            <listitem>
+              <para>Reduce the global console verbosity via
+              <envar>OPCGW_LOG_LEVEL=warn</envar> (the per-module files
+              still capture at <literal>TRACE</literal>, preserving
+              forensic detail).</para>
+            </listitem>
+            <listitem>
+              <para>If using a custom <filename>log4rs.yaml</filename>
+              (legacy from pre-tracing days), inspect its
+              <literal>rolling_file</literal> + <literal>size</literal>
+              + <literal>roller</literal> stanza for the rotation
+              window.</para>
+            </listitem>
+          </orderedlist>
+        </section>
+      </section>
+    </chapter>
+
+  <!-- ============================================ -->
+  <!-- CHAPTER: UPGRADE AND MIGRATION -->
+  <!-- ============================================ -->
+  <chapter id="ch-upgrade">
+    <title>Upgrade and Migration</title>
+
+    <para>This chapter covers operator-driven upgrade procedures. The
+    canonical, exhaustively-tested runbook for the v2.0-rc → v2.0 GA
+    transition (payload-bearing
+    <literal>MetricType</literal>; SQLite schema v006 → v008) lives in
+    <filename>docs/deployment-guide.md</filename>.
+    The summary below is operator-facing; defer to the
+    deployment-guide for the per-line architectural rationale, SLA
+    tests, and the v007 / v008 migration internals.</para>
+
+      <section id="sec-upgrade-pre-flight">
+        <title>Pre-upgrade Checklist</title>
+        <para>Before stopping the current (v2.0-rc) gateway:</para>
+        <orderedlist>
+          <listitem>
+            <para><emphasis>Take a file-level backup of the SQLite
+            database.</emphasis> The backup is your
+            <emphasis>only</emphasis> rollback path — the migration is
+            one-way. Use the explicit three-path form, never a glob, so
+            unrelated backup files (e.g.
+            <filename>opcgw.db.bak.YYYY-MM-DD</filename>) are not
+            collected:</para>
+            <screen>cp /path/to/opcgw.db /path/to/opcgw.db.pre-2.0.bak
+cp /path/to/opcgw.db-wal /path/to/opcgw.db-wal.pre-2.0.bak 2&gt;/dev/null || true
+cp /path/to/opcgw.db-shm /path/to/opcgw.db-shm.pre-2.0.bak 2&gt;/dev/null || true</screen>
+          </listitem>
+          <listitem>
+            <para><emphasis>Identify your current schema version.</emphasis>
+            Run the bundled pre-flight script:</para>
+            <screen>./scripts/check-schema-version.sh /path/to/opcgw.db</screen>
+            <para>The script wraps <literal>PRAGMA user_version</literal>
+            with an operator-friendly recommendation, and pre-checks
+            that the file is actually an opcgw database (has the
+            <literal>metric_values</literal> and
+            <literal>metric_history</literal> tables) so you don't
+            accidentally point it at an unrelated SQLite file (Firefox
+            <filename>places.sqlite</filename>, etc.).</para>
+            <itemizedlist>
+              <listitem>
+                <para>Version <emphasis>6</emphasis> — pre-2.0.
+                Migration applies.</para>
+              </listitem>
+              <listitem>
+                <para>Version <emphasis>7</emphasis> — interrupted prior
+                upgrade left the database between v007 and v008.
+                Starting the v2.0 gateway will complete the migration
+                (idempotent — only v008 will be re-applied).</para>
+              </listitem>
+              <listitem>
+                <para>Version <emphasis>8</emphasis> — already migrated.
+                No action needed.</para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+          <listitem>
+            <para><emphasis>Decide Path A vs Path B.</emphasis> Path A
+            preserves legacy (pre-2.0) historical rows (surfacing them as
+            <literal>BadDataUnavailable</literal> for one poll
+            interval); Path B drops the database file and starts fresh.
+            For most production deployments Path A is the right choice;
+            test / dev gateways and deployments where legacy history
+            is uninteresting can use Path B.</para>
+          </listitem>
+        </orderedlist>
+      </section>
+
+      <section id="sec-upgrade-path-a">
+        <title>Path A: In-Place Auto-Migration (Default)</title>
+        <para>The recommended path for operators who want to preserve
+        historical metric rows captured under the v2.0-rc schema.</para>
+
+        <orderedlist>
+          <listitem>
+            <para>Stop the v2.0-rc gateway gracefully:</para>
+            <screen># systemd:
+sudo systemctl stop opcgw
+
+# Docker Compose:
+docker compose stop opcgw
+
+# Foreground binary:  Ctrl-C  or  kill -TERM &lt;pid&gt;</screen>
+          </listitem>
+          <listitem>
+            <para>Replace the binary or pull the new image:</para>
+            <screen># Docker Hub:
+docker pull docker.io/gcorbaz/opcgw:2.0
+
+# GHCR mirror:
+docker pull ghcr.io/guycorbaz/opcgw:2.0
+
+# Source build:
+cargo install --path .</screen>
+          </listitem>
+          <listitem>
+            <para>Start the v2.0 gateway pointing at the same
+            <filename>opcgw.db</filename> file. The
+            <literal>run_migrations()</literal> path applies v007 (typed
+            value columns — metadata-only ALTER TABLE) and v008
+            (exactly-one-non-NULL <literal>CHECK</literal> constraint,
+            via <literal>CREATE TABLE … AS SELECT</literal> wrapped in
+            <literal>BEGIN/COMMIT</literal>) automatically. Legacy
+            rows are tagged
+            <literal>value_type = 'legacy'</literal> with NULL typed
+            columns by the v007 column default; no rows are
+            dropped.</para>
+          </listitem>
+          <listitem>
+            <para>Verify the migrations applied. Pick the recipe
+            matching your deployment shape:</para>
+            <screen># systemd:
+journalctl -u opcgw -n 200 | grep -E "Applied migration v00(7|8)"
+
+# Docker Compose:
+docker compose logs opcgw | grep -E "Applied migration v00(7|8)"
+
+# Foreground binary:
+tail -n 200 log/opc_ua_gw.log | grep -E "Applied migration v00(7|8)"</screen>
+            <para>You should see two info lines:</para>
+            <programlisting>Applied migration v007_typed_value_columns          version=7
+Applied migration v008_typed_value_constraints      version=8</programlisting>
+          </listitem>
+          <listitem>
+            <para>Wait for the first poll cycle. OPC UA clients will see
+            <literal>BadDataUnavailable</literal> on legacy rows for the
+            duration of one poll interval. Once the poller UPSERTs each
+            metric with a typed payload, the legacy rows are replaced
+            and OPC UA Reads return the real measurement.</para>
+          </listitem>
+        </orderedlist>
+      </section>
+
+      <section id="sec-upgrade-path-b">
+        <title>Path B: Drop-and-Recreate</title>
+        <para>The right path for operators who do not need legacy
+        history (test deployments, dev gateways, or production
+        gateways where historical rows are uninteresting under the new
+        typed-payload contract).</para>
+
+        <orderedlist>
+          <listitem>
+            <para>Stop the v2.0-rc gateway (same recipes as Path
+            A).</para>
+          </listitem>
+          <listitem>
+            <para>Remove the database file and its sidecar files. Use
+            the explicit three-path form, NOT a glob — a glob like
+            <filename>opcgw.db*</filename> would also remove your
+            <filename>opcgw.db.pre-2.0.bak</filename> backup file
+            and any operator-managed backup snapshots in the same
+            directory:</para>
+            <screen>rm /path/to/opcgw.db /path/to/opcgw.db-wal /path/to/opcgw.db-shm</screen>
+            <para>For Docker bind-mounts, run the
+            <command>rm</command> on the host side directory that's
+            bind-mounted into the container.</para>
+          </listitem>
+          <listitem>
+            <para>Replace the binary or pull the new image (same as
+            Path A).</para>
+          </listitem>
+          <listitem>
+            <para>Start the v2.0 gateway. It creates a fresh
+            v008-schema database with zero rows; the next poll cycle
+            populates <literal>metric_values</literal> with real typed
+            payloads from the start.</para>
+          </listitem>
+        </orderedlist>
+      </section>
+
+      <section id="sec-upgrade-rollback">
+        <title>Rollback Contract</title>
+        <para>The 2.0 payload migration is
+        <emphasis>one-way</emphasis>. v007 column additions cannot be
+        cleanly dropped without breaking post-migration data integrity
+        contracts (the typed columns become NOT-NULL-able after v008's
+        <literal>CHECK</literal> lands, and the
+        <literal>MetricType</literal> enum no longer carries a string
+        representation). v008's exactly-one-non-NULL
+        <literal>CHECK</literal> is not in v006 and cannot be added to
+        a v006-shaped database without first running v007.</para>
+
+        <para><emphasis>The only rollback path is to restore the
+        pre-upgrade backup file</emphasis> taken in the pre-upgrade
+        checklist, then run the v2.0-rc binary against it:</para>
+        <screen># Stop the v2.0 gateway first.
+cp /path/to/opcgw.db.pre-2.0.bak /path/to/opcgw.db
+# Restore the v2.0-rc binary or revert the Docker image tag.
+# Start the v2.0-rc gateway.</screen>
+        <para>There is no in-tree rollback tool. <emphasis>Take the
+        backup BEFORE starting the upgrade</emphasis> — the migration
+        starts the moment you launch the v2.0 binary against a v006
+        database.</para>
+      </section>
+
+      <section id="sec-upgrade-verification">
+        <title>Post-Migration Verification</title>
+        <orderedlist>
+          <listitem>
+            <para>Schema version is <literal>8</literal>:</para>
+            <screen>sqlite3 /path/to/opcgw.db "PRAGMA user_version;"
+# Expected output: 8</screen>
+          </listitem>
+          <listitem>
+            <para>First poll cycle completed — look for
+            <literal>operation="poll_cycle_end"</literal> in the
+            gateway logs (Path A: this may take up to one
+            <literal>[chirpstack].polling_frequency</literal>
+            interval; default 10 s).</para>
+            <screen># systemd:
+journalctl -u opcgw | grep "poll_cycle_end" | head -3
+
+# Docker Compose:
+docker compose logs opcgw 2&gt;&amp;1 | grep "poll_cycle_end" | head -3</screen>
+          </listitem>
+          <listitem>
+            <para>OPC UA Read returns the actual measurement payload —
+            <emphasis>not</emphasis> the discriminant string
+            (<literal>Variant::String("Float")</literal>),
+            <emphasis>not</emphasis>
+            <literal>BadDataUnavailable</literal> for any typed row.
+            Connect a SCADA client (UaExpert, FUXA, Ignition) and read a
+            metric variable. Expected
+            <literal>DataValue.value</literal> per
+            <literal>MetricType</literal> variant: see the mapping
+            table in <xref linkend="sec-application-config"/>.</para>
+          </listitem>
+          <listitem>
+            <para>(Path A only) Legacy rows clear within one poll
+            interval. Re-read the same metric a poll interval later;
+            if it previously returned
+            <literal>BadDataUnavailable</literal>, it now returns the
+            freshly UPSERTed typed payload.</para>
+          </listitem>
+        </orderedlist>
+      </section>
+
+      <section id="sec-upgrade-sla">
+        <title>SLA Expectation</title>
+        <para>For typical residential / small-scale deployments
+        (≤10k rows per table, ≤10 MB total database size), the
+        v007 + v008 migrations complete in
+        <emphasis>under 5 seconds</emphasis>. This SLA is pinned by
+        regression tests (<literal>test_v006_to_v008_full_upgrade_path_under_5s</literal>
+        and per-migration siblings).</para>
+        <para>For larger databases (≥100 MB, typically ≥500k
+        historical rows), v008's
+        <literal>CREATE TABLE … AS SELECT</literal> pattern is the
+        dominant cost and scales roughly linearly with row count.
+        <emphasis>Expect a multi-minute startup delay on the first
+        upgrade run</emphasis> — the gateway appears unresponsive
+        (OPC UA port not yet bound) until the migration completes.
+        The auto-migration is synchronous before the OPC UA server
+        binds its port — operator-visible behaviour is "the gateway
+        takes longer than usual to start the first time after
+        upgrading", which is expected and not a defect.</para>
+      </section>
+
+      <section id="sec-upgrade-gotchas">
+        <title>Common Gotchas</title>
+        <para>The full list with examples lives in
+        <filename>docs/deployment-guide.md § "Common
+        gotchas"</filename>. The six pitfalls operators most commonly
+        hit:</para>
+        <orderedlist>
+          <listitem>
+            <para>Legacy rows look like "missing data" in the web
+            dashboard and as <literal>BadDataUnavailable</literal> in
+            OPC UA Reads — <emphasis>for one poll interval only</emphasis>.
+            Wait one cycle.</para>
+          </listitem>
+          <listitem>
+            <para>The <literal>metric_history</literal> table is
+            migrated the same way as
+            <literal>metric_values</literal>. Legacy rows surface in
+            HistoryRead responses as
+            <literal>DataValue { value: None, status: BadDataUnavailable }</literal>
+            — NOT silently dropped.</para>
+          </listitem>
+          <listitem>
+            <para>New audit events may fire on first startup. v2.0
+            introduced five <literal>event="metric_*"</literal> audit
+            lines; if a v006 database happens to contain legacy
+            non-finite rows, the defensive guards emit warns. Operator-
+            actionable but not blocking.</para>
+          </listitem>
+          <listitem>
+            <para><literal>run_migrations()</literal> is idempotent.
+            Re-running the v2.0 binary against a v007 or v008 database
+            is a no-op.</para>
+          </listitem>
+          <listitem>
+            <para>v008's
+            <literal>CREATE TABLE … AS SELECT</literal> is
+            <literal>BEGIN/COMMIT</literal>-wrapped. A process kill
+            mid-v008 leaves the database in a consistent v007 state;
+            restart the gateway and v008 retries.</para>
+          </listitem>
+          <listitem>
+            <para>Docker bind mounts preserve <filename>opcgw.db</filename>
+            across container replacement — Path A "just works" with the
+            standard <command>docker compose pull &amp;&amp; docker
+            compose up -d</command> workflow because the database file
+            lives on the host. Path B requires
+            <command>rm ./opcgw.db ./opcgw.db-wal ./opcgw.db-shm</command>
+            in the host-side bind-mount directory (avoid the
+            <filename>opcgw.db*</filename> glob).</para>
+          </listitem>
+        </orderedlist>
+      </section>
+    </chapter>
+
+  <!-- ============================================ -->
+  <!-- APPENDIX: CONFIGURATION REFERENCE -->
+  <!-- ============================================ -->
+  <appendix id="app-config-reference">
+    <title>Configuration Reference</title>
+    <para>Quick-lookup table for every TOML key. See
+    <xref linkend="ch-configuration"/> for narrative descriptions and
+    examples.</para>
+
+    <table frame="all">
+      <title>Configuration keys</title>
+      <tgroup cols="4">
+        <thead>
+          <row>
+            <entry>Section.Key</entry>
+            <entry>Type</entry>
+            <entry>Default</entry>
+            <entry>Override</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry><literal>global.debug</literal></entry>
+            <entry>bool</entry>
+            <entry><literal>false</literal></entry>
+            <entry><literal>OPCGW_GLOBAL__DEBUG</literal></entry>
+          </row>
+          <row>
+            <entry><literal>logging.dir</literal></entry>
+            <entry>path</entry>
+            <entry><literal>./log</literal></entry>
+            <entry><literal>OPCGW_LOG_DIR</literal>,
+            <literal>OPCGW_LOGGING__DIR</literal></entry>
+          </row>
+          <row>
+            <entry><literal>logging.level</literal></entry>
+            <entry>enum</entry>
+            <entry><literal>info</literal></entry>
+            <entry><literal>OPCGW_LOG_LEVEL</literal>,
+            <literal>OPCGW_LOGGING__LEVEL</literal>, CLI
+            <literal>-d</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack.server_address</literal></entry>
+            <entry>URL</entry>
+            <entry>—</entry>
+            <entry><literal>OPCGW_CHIRPSTACK__SERVER_ADDRESS</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack.api_token</literal></entry>
+            <entry>string</entry>
+            <entry>—</entry>
+            <entry><literal>OPCGW_CHIRPSTACK__API_TOKEN</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack.tenant_id</literal></entry>
+            <entry>UUID</entry>
+            <entry>—</entry>
+            <entry><literal>OPCGW_CHIRPSTACK__TENANT_ID</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack.polling_frequency</literal></entry>
+            <entry>seconds</entry>
+            <entry><literal>10</literal></entry>
+            <entry><literal>OPCGW_CHIRPSTACK__POLLING_FREQUENCY</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack.retry</literal></entry>
+            <entry>int</entry>
+            <entry><literal>10</literal></entry>
+            <entry><literal>OPCGW_CHIRPSTACK__RETRY</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack.delay</literal></entry>
+            <entry>seconds</entry>
+            <entry><literal>10</literal></entry>
+            <entry><literal>OPCGW_CHIRPSTACK__DELAY</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack.list_page_size</literal></entry>
+            <entry>int</entry>
+            <entry><literal>100</literal></entry>
+            <entry><literal>OPCGW_CHIRPSTACK__LIST_PAGE_SIZE</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.application_name</literal></entry>
+            <entry>string</entry>
+            <entry>—</entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.application_uri</literal></entry>
+            <entry>URI</entry>
+            <entry>—</entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.product_uri</literal></entry>
+            <entry>URI</entry>
+            <entry>—</entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.diagnostics_enabled</literal></entry>
+            <entry>bool</entry>
+            <entry><literal>false</literal></entry>
+            <entry><literal>OPCGW_OPCUA__DIAGNOSTICS_ENABLED</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.host_ip_address</literal></entry>
+            <entry>IP</entry>
+            <entry>first interface</entry>
+            <entry><literal>OPCGW_OPCUA__HOST_IP_ADDRESS</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.host_port</literal></entry>
+            <entry>port</entry>
+            <entry><literal>4840</literal></entry>
+            <entry><literal>OPCGW_OPCUA__HOST_PORT</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.create_sample_keypair</literal></entry>
+            <entry>bool</entry>
+            <entry><literal>false</literal></entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.certificate_path</literal></entry>
+            <entry>path</entry>
+            <entry>—</entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.private_key_path</literal></entry>
+            <entry>path</entry>
+            <entry>—</entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.trust_client_cert</literal></entry>
+            <entry>bool</entry>
+            <entry><literal>false</literal></entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.check_cert_time</literal></entry>
+            <entry>bool</entry>
+            <entry><literal>true</literal></entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.pki_dir</literal></entry>
+            <entry>path</entry>
+            <entry><literal>./pki</literal></entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>opcua.user_name</literal></entry>
+            <entry>string</entry>
+            <entry>—</entry>
+            <entry><literal>OPCGW_OPCUA__USER_NAME</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.user_password</literal></entry>
+            <entry>string</entry>
+            <entry>—</entry>
+            <entry><literal>OPCGW_OPCUA__USER_PASSWORD</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.stale_threshold_seconds</literal></entry>
+            <entry>seconds</entry>
+            <entry><literal>120</literal></entry>
+            <entry><literal>OPCGW_OPCUA__STALE_THRESHOLD_SECONDS</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.max_connections</literal></entry>
+            <entry>int</entry>
+            <entry><literal>10</literal></entry>
+            <entry><literal>OPCGW_OPCUA__MAX_CONNECTIONS</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.max_subscriptions_per_session</literal></entry>
+            <entry>int</entry>
+            <entry><literal>10</literal></entry>
+            <entry><literal>OPCGW_OPCUA__MAX_SUBSCRIPTIONS_PER_SESSION</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.max_monitored_items_per_sub</literal></entry>
+            <entry>int</entry>
+            <entry><literal>1000</literal></entry>
+            <entry><literal>OPCGW_OPCUA__MAX_MONITORED_ITEMS_PER_SUB</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.max_message_size</literal></entry>
+            <entry>bytes</entry>
+            <entry><literal>327675</literal></entry>
+            <entry><literal>OPCGW_OPCUA__MAX_MESSAGE_SIZE</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.max_chunk_count</literal></entry>
+            <entry>int</entry>
+            <entry><literal>5</literal></entry>
+            <entry><literal>OPCGW_OPCUA__MAX_CHUNK_COUNT</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opcua.max_history_data_results_per_node</literal></entry>
+            <entry>int</entry>
+            <entry><literal>10000</literal></entry>
+            <entry><literal>OPCGW_OPCUA__MAX_HISTORY_DATA_RESULTS_PER_NODE</literal></entry>
+          </row>
+          <row>
+            <entry><literal>web.enabled</literal></entry>
+            <entry>bool</entry>
+            <entry><literal>false</literal></entry>
+            <entry><literal>OPCGW_WEB__ENABLED</literal></entry>
+          </row>
+          <row>
+            <entry><literal>web.port</literal></entry>
+            <entry>port</entry>
+            <entry><literal>8080</literal></entry>
+            <entry><literal>OPCGW_WEB__PORT</literal></entry>
+          </row>
+          <row>
+            <entry><literal>web.bind_address</literal></entry>
+            <entry>IP</entry>
+            <entry><literal>0.0.0.0</literal></entry>
+            <entry><literal>OPCGW_WEB__BIND_ADDRESS</literal></entry>
+          </row>
+          <row>
+            <entry><literal>web.auth_realm</literal></entry>
+            <entry>string</entry>
+            <entry><literal>opcgw</literal></entry>
+            <entry><literal>OPCGW_WEB__AUTH_REALM</literal></entry>
+          </row>
+          <row>
+            <entry><literal>web.allowed_origins</literal></entry>
+            <entry>list of URLs</entry>
+            <entry><literal>["http://&lt;bind&gt;:&lt;port&gt;"]</literal></entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>command_delivery.status_poll_interval_secs</literal></entry>
+            <entry>seconds</entry>
+            <entry><literal>5</literal></entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>command_delivery.confirmation_timeout_secs</literal></entry>
+            <entry>seconds</entry>
+            <entry><literal>60</literal></entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>command_delivery.timeout_check_interval_secs</literal></entry>
+            <entry>seconds</entry>
+            <entry><literal>10</literal></entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>command_delivery.history_retention_days</literal></entry>
+            <entry>days</entry>
+            <entry><literal>7</literal></entry>
+            <entry>—</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </appendix>
+
+  <!-- ============================================ -->
+  <!-- APPENDIX: ENVIRONMENT VARIABLE REFERENCE -->
+  <!-- ============================================ -->
+  <appendix id="app-env-reference">
+    <title>Environment Variable Reference</title>
+    <para>All environment variables use the <literal>OPCGW_</literal>
+    prefix, with <literal>__</literal> (double underscore) separating
+    nested configuration keys. They are set in the
+    <filename>.env</filename> file and override the corresponding
+    configuration value — environment variables always win.</para>
+
+    <table frame="all">
+      <title>Environment variables</title>
+      <tgroup cols="3">
+        <colspec colname="c1"/>
+        <colspec colname="c2"/>
+        <colspec colname="c3"/>
+        <thead>
+          <row>
+            <entry>Variable</entry>
+            <entry>Purpose</entry>
+            <entry>Default</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry namest="c1" nameend="c3" align="center">
+            <emphasis role="strong">Required (secrets)</emphasis></entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_CHIRPSTACK__API_TOKEN</literal></entry>
+            <entry>ChirpStack API token (list/read permissions for your
+            tenant)</entry>
+            <entry>required, no default</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__USER_PASSWORD</literal></entry>
+            <entry>OPC UA + web UI login password</entry>
+            <entry>required, no default</entry>
+          </row>
+          <row>
+            <entry namest="c1" nameend="c3" align="center">
+            <emphasis role="strong">ChirpStack</emphasis></entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_CHIRPSTACK__SERVER_ADDRESS</literal></entry>
+            <entry>ChirpStack gRPC endpoint (host:port)</entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_CHIRPSTACK__LIST_PAGE_SIZE</literal></entry>
+            <entry>page size for paged ChirpStack list calls</entry>
+            <entry>100</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_CHIRPSTACK__INVENTORY_CACHE_TTL_SECONDS</literal></entry>
+            <entry>how long discovered inventory is cached</entry>
+            <entry>60</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_CHIRPSTACK__INVENTORY_UPLINK_MAX_WAIT_SECONDS</literal></entry>
+            <entry>max wait for a device uplink during discovery</entry>
+            <entry>5</entry>
+          </row>
+          <row>
+            <entry namest="c1" nameend="c3" align="center">
+            <emphasis role="strong">OPC UA</emphasis></entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__USER_NAME</literal></entry>
+            <entry>OPC UA + web UI login user name</entry>
+            <entry>opcua-user</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__HOST_PORT</literal></entry>
+            <entry>OPC UA listen port (if you change it, publish the same port
+            in <filename>docker-compose.yml</filename>)</entry>
+            <entry>4840</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__MAX_CONNECTIONS</literal></entry>
+            <entry>max concurrent OPC UA sessions</entry>
+            <entry>10</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPC_UA_STALE_THRESHOLD_SECONDS</literal></entry>
+            <entry>age after which a value is flagged stale</entry>
+            <entry>120</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__MAX_HISTORY_DATA_RESULTS_PER_NODE</literal></entry>
+            <entry>cap on rows returned per HistoryRead call</entry>
+            <entry>10000</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__MAX_SUBSCRIPTIONS_PER_SESSION</literal></entry>
+            <entry>subscription shaping limit</entry>
+            <entry>10</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__MAX_MONITORED_ITEMS_PER_SUB</literal></entry>
+            <entry>subscription shaping limit</entry>
+            <entry>1000</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__MAX_MESSAGE_SIZE</literal></entry>
+            <entry>OPC UA message-size limit</entry>
+            <entry>327675</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_OPCUA__MAX_CHUNK_COUNT</literal></entry>
+            <entry>OPC UA chunk-count limit</entry>
+            <entry>5</entry>
+          </row>
+          <row>
+            <entry namest="c1" nameend="c3" align="center">
+            <emphasis role="strong">Web UI</emphasis></entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_WEB__ENABLED</literal></entry>
+            <entry>enable the web UI</entry>
+            <entry>true</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_WEB__PORT</literal></entry>
+            <entry>web UI port</entry>
+            <entry>8080</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_WEB__BIND_ADDRESS</literal></entry>
+            <entry>web UI bind address</entry>
+            <entry>0.0.0.0</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_WEB__AUTH_REALM</literal></entry>
+            <entry>HTTP Basic auth realm string</entry>
+            <entry>opcgw</entry>
+          </row>
+          <row>
+            <entry namest="c1" nameend="c3" align="center">
+            <emphasis role="strong">Logging / general</emphasis></entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_LOG_LEVEL</literal></entry>
+            <entry>log verbosity: error|warn|info|debug|trace</entry>
+            <entry>info</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_LOG_DIR</literal></entry>
+            <entry>directory for log files</entry>
+            <entry>./log</entry>
+          </row>
+          <row>
+            <entry><literal>OPCGW_CONFIG_PATH</literal></entry>
+            <entry>path to the bootstrap config.toml</entry>
+            <entry>config/config.toml</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+
+    <para>The two required secret values are never written to SQLite;
+    they are read only from the environment (or from
+    <filename>config/secrets.toml</filename>).</para>
+  </appendix>
+
+  <!-- ============================================ -->
+  <!-- APPENDIX: OPC UA ADDRESS SPACE -->
+  <!-- ============================================ -->
+  <appendix id="app-opcua-address-space">
+    <title>OPC UA Address Space</title>
+    <para>Browsing the configured root yields:</para>
+    <programlisting>Objects/
+└── opcgw/
+    ├── Gateway/
+    │   ├── LastPollTimestamp     (String, RFC 3339 or NULL)
+    │   ├── error_count           (Int32)
+    │   └── chirpstack_available  (Boolean)
+    └── &lt;application_name&gt;/        (one folder per [[application]])
+        └── &lt;device_name&gt;/         (one folder per [[application.device]])
+            ├── &lt;metric_name&gt;       (Variant per [[..read_metric]].metric_type)
+            └── &lt;command_name&gt;      (writable, per [[..command]])</programlisting>
+    <para>Every read returns a <literal>StatusCode</literal>. For uplink
+    metrics it is derived from the metric's age (Good / Uncertain / Bad).
+    For Gateway-folder reads it is always <literal>Good</literal>, except
+    that <literal>LastPollTimestamp</literal> may be <literal>NULL</literal>
+    (still reported with <literal>Good</literal> status — the
+    <literal>NULL</literal> value itself is the signal).</para>
+  </appendix>
+
+  <!-- ============================================ -->
+  <!-- APPENDIX: OPERATION NAMES -->
+  <!-- ============================================ -->
+  <appendix id="app-operation-names">
+    <title>Operation Names</title>
+    <para>Routine operational log lines carry an
+    <literal>operation = "&lt;name&gt;"</literal> field. The table below
+    is a quick lookup of the most common names and where they come
+    from.</para>
+
+    <table frame="all">
+      <title>Common operation names</title>
+      <tgroup cols="3">
+        <thead>
+          <row>
+            <entry>Operation</entry>
+            <entry>Emitted by</entry>
+            <entry>Level</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry><literal>poll_cycle_start</literal></entry>
+            <entry>poller, every cycle</entry>
+            <entry><literal>info</literal></entry>
+          </row>
+          <row>
+            <entry><literal>device_polled</literal></entry>
+            <entry>poller, per device</entry>
+            <entry><literal>debug</literal></entry>
+          </row>
+          <row>
+            <entry><literal>device_poll</literal></entry>
+            <entry>poller, on per-device failure</entry>
+            <entry><literal>warn</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack_connect</literal></entry>
+            <entry>poller, gRPC channel and probe paths</entry>
+            <entry><literal>info</literal> /
+            <literal>warn</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack_request</literal></entry>
+            <entry>poller, on transport errors
+            (deadline / unavailable / cancelled)</entry>
+            <entry><literal>warn</literal></entry>
+          </row>
+          <row>
+            <entry><literal>chirpstack_outage</literal></entry>
+            <entry>poller, first per-cycle ChirpStack failure</entry>
+            <entry><literal>warn</literal></entry>
+          </row>
+          <row>
+            <entry><literal>error_spike</literal></entry>
+            <entry>poller, when error_count delta ≥ 5</entry>
+            <entry><literal>warn</literal></entry>
+          </row>
+          <row>
+            <entry><literal>retry_schedule</literal></entry>
+            <entry>poller, on TCP probe retry</entry>
+            <entry><literal>info</literal></entry>
+          </row>
+          <row>
+            <entry><literal>metric_parse</literal></entry>
+            <entry>poller, invalid boolean encoding</entry>
+            <entry><literal>warn</literal></entry>
+          </row>
+          <row>
+            <entry><literal>batch_write</literal></entry>
+            <entry>poller, every batch flush</entry>
+            <entry><literal>debug</literal> /
+            <literal>warn</literal></entry>
+          </row>
+          <row>
+            <entry><literal>storage_query</literal></entry>
+            <entry>storage layer, every query</entry>
+            <entry><literal>debug</literal> /
+            <literal>warn</literal></entry>
+          </row>
+          <row>
+            <entry><literal>txn_begin</literal>,
+            <literal>txn_commit</literal>,
+            <literal>txn_rollback</literal></entry>
+            <entry>storage layer, transaction boundaries</entry>
+            <entry><literal>trace</literal></entry>
+          </row>
+          <row>
+            <entry><literal>opc_ua_read</literal></entry>
+            <entry>OPC UA server, every metric read</entry>
+            <entry><literal>info</literal> span</entry>
+          </row>
+          <row>
+            <entry><literal>staleness_check</literal></entry>
+            <entry>OPC UA server, every metric read</entry>
+            <entry><literal>debug</literal></entry>
+          </row>
+          <row>
+            <entry><literal>staleness_transition</literal></entry>
+            <entry>OPC UA server, on status code change</entry>
+            <entry><literal>info</literal>
+            (<literal>debug</literal> on first observation)</entry>
+          </row>
+          <row>
+            <entry><literal>staleness_boundary</literal></entry>
+            <entry>OPC UA server, ±5 s of threshold</entry>
+            <entry><literal>debug</literal></entry>
+          </row>
+          <row>
+            <entry><literal>health_metric_read</literal></entry>
+            <entry>OPC UA server, Gateway folder reads</entry>
+            <entry><literal>debug</literal>
+            (<literal>warn</literal> on no-data-yet)</entry>
+          </row>
+          <row>
+            <entry><literal>gateway_status_init</literal></entry>
+            <entry>OPC UA server, first uninitialised read</entry>
+            <entry><literal>info</literal>
+            (once per process)</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+
+    <para>The complete reference, including expected fields and
+    remediation tips, lives in
+    <filename>docs/logging.md</filename>.</para>
+
+    <para>Reserved operation names (planned for a future release, not
+    yet emitted):</para>
+    <itemizedlist>
+      <listitem>
+        <para><literal>recovery_attempt</literal>,
+        <literal>recovery_complete</literal>,
+        <literal>recovery_failed</literal> — auto-recovery
+        from ChirpStack outages.</para>
+      </listitem>
+    </itemizedlist>
+  </appendix>
+
+  <!-- ============================================ -->
+  <!-- APPENDIX: AUDIT AND DIAGNOSTIC EVENTS -->
+  <!-- ============================================ -->
+  <appendix id="app-audit-events">
+    <title>Audit and Diagnostic Events</title>
+    <para>Security-relevant audit lines and one-shot diagnostic lines
+    carry an <literal>event=</literal> field (rather than the
+    <literal>operation=</literal> field used by routine operational
+    lines), which makes them easy to filter with
+    <command>grep 'event="..."' log/*.log</command>. The table below
+    indexes the event names; the full reference (per-event
+    <literal>reason=</literal> values, field schemas, and severity) lives
+    in <filename>docs/logging.md</filename> and
+    <filename>docs/security.md</filename>.</para>
+
+    <table frame="all">
+      <title>Audit and diagnostic events</title>
+      <tgroup cols="3">
+        <thead>
+          <row>
+            <entry>event=</entry>
+            <entry>Level</entry>
+            <entry>Meaning</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry><literal>opcua_auth_failed</literal></entry>
+            <entry>warn (audit)</entry>
+            <entry>OPC UA authentication failure</entry>
+          </row>
+          <row>
+            <entry><literal>opcua_session_count</literal></entry>
+            <entry>info (diag)</entry>
+            <entry>session-count gauge, every 5 s</entry>
+          </row>
+          <row>
+            <entry><literal>opcua_session_count_at_limit</literal></entry>
+            <entry>warn (audit)</entry>
+            <entry>session rejected at the configured cap</entry>
+          </row>
+          <row>
+            <entry><literal>opcua_limits_configured</literal></entry>
+            <entry>info (diag)</entry>
+            <entry>startup echo of subscription / message-size
+            limits</entry>
+          </row>
+          <row>
+            <entry><literal>nfr12_correlation_check</literal></entry>
+            <entry>warn (one-shot)</entry>
+            <entry>log level below info weakens source-IP
+            correlation for auth failures</entry>
+          </row>
+          <row>
+            <entry><literal>web_server_started</literal></entry>
+            <entry>info (diag)</entry>
+            <entry>web server bound and listening</entry>
+          </row>
+          <row>
+            <entry><literal>web_auth_failed</literal></entry>
+            <entry>warn (audit)</entry>
+            <entry>web UI Basic-auth failure
+            (<literal>reason</literal> ∈ missing, malformed_scheme,
+            malformed_base64, missing_colon, user_mismatch,
+            password_mismatch)</entry>
+          </row>
+          <row>
+            <entry><literal>application_*</literal> /
+            <literal>device_*</literal> /
+            <literal>command_*</literal>
+            (created / updated / deleted /
+            <literal>*_crud_rejected</literal>)</entry>
+            <entry>info / warn (audit)</entry>
+            <entry>configuration CRUD mutations and validation
+            rejections</entry>
+          </row>
+          <row>
+            <entry><literal>topology_change_detected</literal></entry>
+            <entry>info (diag)</entry>
+            <entry>a change that adds or removes applications /
+            devices / metrics / commands</entry>
+          </row>
+          <row>
+            <entry><literal>address_space_mutation_succeeded</literal>
+            / <literal>address_space_mutation_failed</literal></entry>
+            <entry>info / warn (audit)</entry>
+            <entry>OPC UA address-space runtime mutation
+            outcome</entry>
+          </row>
+          <row>
+            <entry><literal>metric_parse</literal></entry>
+            <entry>warn</entry>
+            <entry>poller-side payload conversion
+            (<literal>reason</literal> ∈ invalid_bool, non_finite,
+            int_overflow)</entry>
+          </row>
+          <row>
+            <entry><literal>metric_read</literal></entry>
+            <entry>info / warn</entry>
+            <entry>OPC UA read value narrowing
+            (<literal>reason</literal> ∈ no_payload,
+            narrowing_overflow, narrowing_underflow)</entry>
+          </row>
+          <row>
+            <entry><literal>metric_history_read</literal></entry>
+            <entry>warn</entry>
+            <entry>OPC UA HistoryRead per-row conversion
+            (<literal>reason</literal> ∈ schema_drift,
+            unparseable_timestamp, narrowing_overflow,
+            narrowing_underflow)</entry>
+          </row>
+          <row>
+            <entry><literal>metric_history_summary</literal></entry>
+            <entry>trace</entry>
+            <entry>aggregate skip counts per HistoryRead call</entry>
+          </row>
+          <row>
+            <entry><literal>metric_view_serialize</literal></entry>
+            <entry>debug / warn / info</entry>
+            <entry>web-layer JSON serialization
+            (<literal>reason</literal> ∈ non_finite,
+            int_precision_lossy)</entry>
+          </row>
+          <row>
+            <entry><literal>picker_opened</literal> /
+            <literal>picker_manual_fallback</literal> /
+            <literal>picker_audit_rejected</literal></entry>
+            <entry>info / warn (audit)</entry>
+            <entry>web-UI inventory picker activity and
+            fallbacks</entry>
+          </row>
+          <row>
+            <entry><literal>drift_view_opened</literal> /
+            <literal>drift_action</literal> /
+            <literal>drift_dismissed</literal></entry>
+            <entry>info (audit)</entry>
+            <entry>inventory drift view activity and operator
+            decisions</entry>
+          </row>
+          <row>
+            <entry><literal>config_toml_unused_warning</literal></entry>
+            <entry>warn (diag)</entry>
+            <entry>config.toml present on disk but SQLite is now
+            authoritative</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+
+    <para>The response returned to a client never depends on whether an
+    audit event fired — a failure that records
+    <literal>event="..._failed"</literal> returns the same status and
+    headers regardless of the internal <literal>reason</literal>. The
+    distinction exists only in the audit log, for forensic
+    purposes.</para>
+  </appendix>
+
+  <!-- ============================================ -->
+  <!-- APPENDIX: GLOSSARY -->
+  <!-- ============================================ -->
+  <appendix id="app-glossary">
+    <title>Glossary</title>
+    <variablelist>
+      <varlistentry>
+        <term>ChirpStack</term>
+        <listitem>
+          <para>Open-source LoRaWAN Network Server that manages devices and
+          collects metrics.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>DashMap</term>
+        <listitem>
+          <para>Sharded concurrent hash map used by opcgw's OPC UA server
+          to track per-metric staleness state without serialising reads on
+          a single mutex.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>DevEUI</term>
+        <listitem>
+          <para>Globally unique 64-bit identifier for a LoRaWAN end-device,
+          used as the <literal>device_id</literal> in opcgw
+          configuration.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Gateway folder</term>
+        <listitem>
+          <para>Synthetic OPC UA folder under the configured root
+          containing the gateway's own health metrics
+          (<literal>LastPollTimestamp</literal>,
+          <literal>error_count</literal>,
+          <literal>chirpstack_available</literal>).</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>gRPC</term>
+        <listitem>
+          <para>Remote-procedure-call framework built on HTTP/2 used by
+          ChirpStack's API.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>LoRaWAN</term>
+        <listitem>
+          <para>Long-Range Wide-Area Network protocol for low-power IoT
+          devices.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>OPC UA</term>
+        <listitem>
+          <para>OPC Unified Architecture, a machine-to-machine
+          communication standard for industrial automation.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><literal>request_id</literal></term>
+        <listitem>
+          <para>Per-OPC-UA-read UUID v4 emitted as a tracing-span field;
+          all log lines emitted while the span is active inherit it,
+          enabling end-to-end correlation by simple
+          <literal>grep</literal>.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>SCADA</term>
+        <listitem>
+          <para>Supervisory Control and Data Acquisition system for
+          monitoring and controlling industrial processes.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>SQLite WAL mode</term>
+        <listitem>
+          <para>Write-Ahead Logging journaling mode that allows multiple
+          readers to operate concurrently with a single writer. opcgw
+          enables WAL at startup; it is the foundation of the lock-free
+          read path.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><literal>StatusCode</literal></term>
+        <listitem>
+          <para>OPC UA per-read status indicator. opcgw maps metric
+          freshness to <literal>Good</literal>,
+          <literal>Uncertain</literal>, or <literal>Bad</literal>.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><literal>tracing</literal></term>
+        <listitem>
+          <para>The Rust crate providing structured, span-aware logging.
+          opcgw emits all log output through it.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>WAL</term>
+        <listitem>
+          <para>Write-Ahead Log — see SQLite WAL mode.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </appendix>
+
+</book>

--- a/migrations/v014_device_source_timestamp.sql
+++ b/migrations/v014_device_source_timestamp.sql
@@ -1,0 +1,12 @@
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+-- (c) [2026] Guy Corbaz
+--
+-- Migration v014 — Issue #153: per-device OPC UA SourceTimestamp mode.
+--
+-- Adds an optional per-device flag. When 0 (default) each served metric value
+-- carries the device's real report time as its OPC UA SourceTimestamp (strict
+-- semantics). When 1, opcgw stamps the value with the gateway's current time
+-- (now()) so SCADA clients that overlay a stale quality on old source
+-- timestamps (e.g. Ignition on slow-cadence LoRaWAN tags) keep the tag Good.
+-- The staleness StatusCode model is unaffected.
+ALTER TABLE devices ADD COLUMN source_timestamp_server INTEGER NOT NULL DEFAULT 0;

--- a/src/chirpstack.rs
+++ b/src/chirpstack.rs
@@ -4760,6 +4760,7 @@ mod tests {
                 device_id: "dev-1".to_string(),
                 device_name: "Dev".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 read_metric_list: vec![],
                 device_command_list: Some(vec![crate::config::DeviceCommandCfg {
                     command_id: 1,

--- a/src/chirpstack_events.rs
+++ b/src/chirpstack_events.rs
@@ -1522,6 +1522,7 @@ mod tests {
             device_id: "dev-dup".to_string(),
             device_name: "Dup".to_string(),
             stale_threshold_seconds: None,
+            source_timestamp_server: false,
             read_metric_list: metrics,
             device_command_list: None,
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -671,6 +671,19 @@ pub struct ChirpstackDevice {
     /// `Good` instead of `Uncertain` between uplinks. Restart-required.
     #[serde(default)]
     pub stale_threshold_seconds: Option<u64>,
+
+    /// Issue #153: per-device OPC UA `SourceTimestamp` mode.
+    ///
+    /// When `false` (default) each served value carries the device's real
+    /// report time as its `SourceTimestamp` — strict OPC UA semantics. When
+    /// `true`, opcgw stamps the value with the gateway's current time (`now()`,
+    /// the same instant as `ServerTimestamp`) so SCADA clients that overlay a
+    /// stale quality on old source timestamps (e.g. Ignition on slow-cadence
+    /// LoRaWAN tags) keep the tag `Good`. The staleness `StatusCode` model is
+    /// unaffected — a genuinely stale metric still reports `Uncertain` once its
+    /// age exceeds the threshold. Restart-required.
+    #[serde(default)]
+    pub source_timestamp_server: bool,
 }
 
 /// Data types supported for OPC UA metric values.

--- a/src/opc_ua.rs
+++ b/src/opc_ua.rs
@@ -1046,6 +1046,14 @@ impl OpcUa {
                         .stale_threshold_seconds
                         .or(self.config.opcua.stale_threshold_seconds)
                         .unwrap_or(DEFAULT_STALE_THRESHOLD_SECS);
+                    // Issue #153: per-device source-timestamp mode. When set,
+                    // the served value carries `now()` as its SourceTimestamp
+                    // instead of the device's real report time — for SCADA
+                    // clients that flag old source timestamps as stale (e.g.
+                    // Ignition on slow-cadence LoRaWAN tags). Captured once at
+                    // address-space build time (same lifecycle as
+                    // `stale_threshold`).
+                    let source_timestamp_server = device.source_timestamp_server;
                     // Story 8-3: register the NodeId → (device_id, chirpstack_metric_name)
                     // mapping so HistoryRead requests can resolve back to the
                     // storage layer. This is the same pair the read callback
@@ -1067,6 +1075,7 @@ impl OpcUa {
                                 device_id.clone().to_string(),
                                 chirpstack_metric_name.clone().to_string(),
                                 stale_threshold,
+                                source_timestamp_server,
                             )
                         })
                 }
@@ -1317,6 +1326,7 @@ impl OpcUa {
         device_id: String,
         metric_name: String,
         stale_threshold: u64,
+        source_timestamp_server: bool,
     ) -> Result<DataValue, opcua::types::StatusCode> {
         // Story 6-1, AC#2: every OPC UA read gets a fresh correlation ID. Wrapping
         // in an info_span causes downstream logs (storage, staleness) to inherit
@@ -1468,12 +1478,26 @@ impl OpcUa {
                 // tag is a value + its source timestamp + quality, and aggregation
                 // is the SCADA's job. The *server* timestamp stays `now()` (when
                 // the gateway produced this response).
+                //
+                // Issue #153: `[opcua].source_timestamp = "server"` overrides the
+                // source timestamp to `now()` for SCADA clients (e.g. Ignition)
+                // that overlay a stale quality on old source timestamps — a
+                // slow-cadence LoRaWAN value is legitimately many minutes old and
+                // does not advance between uplinks. The staleness `StatusCode`
+                // above is computed from the real age regardless, so a genuinely
+                // dead device still reports `Uncertain`.
+                let server_now = DateTime::now();
+                let source_timestamp = if source_timestamp_server {
+                    server_now
+                } else {
+                    DateTime::from(metric_value.timestamp)
+                };
                 let data_value = DataValue {
                     value: Some(variant),
                     status: Some(status_code.bits().into()),
-                    source_timestamp: Some(DateTime::from(metric_value.timestamp)),
+                    source_timestamp: Some(source_timestamp),
                     source_picoseconds: None,
-                    server_timestamp: Some(DateTime::now()),
+                    server_timestamp: Some(server_now),
                     server_picoseconds: None,
                 };
 
@@ -2191,6 +2215,7 @@ mod tests {
             device_id.clone(),
             metric_name.clone(),
             stale_threshold_secs,
+            false,
         );
         assert!(r1.is_ok(), "fresh read should succeed");
 
@@ -2211,6 +2236,7 @@ mod tests {
             device_id.clone(),
             metric_name.clone(),
             stale_threshold_secs,
+            false,
         );
         assert!(r2.is_ok(), "stale read should still return Ok with Uncertain status");
 
@@ -2248,7 +2274,7 @@ mod tests {
             }])
             .expect("seed device-stamped metric");
 
-        let dv = OpcUa::get_value(&backend, &last_status, device_id, metric_name, 60)
+        let dv = OpcUa::get_value(&backend, &last_status, device_id, metric_name, 60, false)
             .expect("read should succeed");
 
         let src = dv
@@ -2264,6 +2290,48 @@ mod tests {
             delta_secs >= 4,
             "source_timestamp must be the ~5s-old device event time, not server now \
              (server - source = {delta_secs}s)"
+        );
+    }
+
+    /// Issue #153: with the per-device `source_timestamp_server` flag ON, the
+    /// OPC UA `source_timestamp` must be the server's `now()` (≈ the
+    /// `server_timestamp`), NOT the ~5 s-old device event time — the opt-in
+    /// behaviour that keeps SCADA clients (e.g. Ignition) from flagging
+    /// slow-cadence tags as stale. The stored value itself is unchanged.
+    #[test]
+    fn source_timestamp_is_server_now_when_flag_set() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::new());
+        let last_status = make_status_cache();
+        let device_id = "dev-ts-server".to_string();
+        let metric_name = "state".to_string();
+
+        let event_time = SystemTime::now() - Duration::from_secs(5);
+        backend
+            .batch_write_metrics(vec![BatchMetricWrite {
+                device_id: device_id.clone(),
+                metric_name: metric_name.clone(),
+                data_type: MetricType::Int(195),
+                timestamp: event_time,
+            }])
+            .expect("seed device-stamped metric");
+
+        // source_timestamp_server = true → source ≈ server now.
+        let dv = OpcUa::get_value(&backend, &last_status, device_id, metric_name, 60, true)
+            .expect("read should succeed");
+
+        let src = dv
+            .source_timestamp
+            .expect("source_timestamp present")
+            .as_chrono();
+        let srv = dv
+            .server_timestamp
+            .expect("server_timestamp present")
+            .as_chrono();
+        let delta_secs = (srv - src).num_seconds().abs();
+        assert!(
+            delta_secs <= 1,
+            "with source_timestamp_server=true the source timestamp must be server now(), \
+             not the ~5s-old device time (|server - source| = {delta_secs}s)"
         );
     }
 
@@ -2402,6 +2470,7 @@ mod tests {
             device_id.clone(),
             metric_name.clone(),
             stale_threshold_secs,
+            false,
         );
         assert!(
             logs_contain("operation=\"staleness_boundary\""),
@@ -2487,6 +2556,7 @@ mod tests {
             "dev-e2e".to_string(),
             "pressure".to_string(),
             60,
+            false,
         );
 
         logs_assert(|lines: &[&str]| {
@@ -2560,6 +2630,7 @@ mod tests {
             "dev-corr".to_string(),
             "humidity".to_string(),
             60,
+            false,
         );
 
         // logs_assert panics if the closure returns Err. We do the actual
@@ -2611,6 +2682,7 @@ mod tests {
             "dev-fields".to_string(),
             "pressure".to_string(),
             60,
+            false,
         );
 
         for canonical_field in [
@@ -2656,6 +2728,7 @@ mod tests {
             "dev-sec".to_string(),
             "secret_marker".to_string(),
             60,
+            false,
         );
 
         assert!(
@@ -2716,6 +2789,7 @@ mod tests {
                 DEVICE_ID.to_string(),
                 METRIC_NAME.to_string(),
                 60,
+                false,
             );
         }
 
@@ -2729,6 +2803,7 @@ mod tests {
                 DEVICE_ID.to_string(),
                 METRIC_NAME.to_string(),
                 60,
+                false,
             );
             samples.push(t0.elapsed().as_micros());
             assert!(r.is_ok(), "every iteration must succeed");
@@ -3256,6 +3331,7 @@ mod tests {
             "ir10_stale_device".to_string(),
             "ir10_stale_metric".to_string(),
             60u64,
+            false,
         )
         .expect("get_value must succeed for stale-but-not-bad typed row");
         // The Variant must carry the REAL payload (12.3), not a zero-default.
@@ -3325,6 +3401,7 @@ mod tests {
             "dev1".to_string(),
             "temp".to_string(),
             3600u64, // IR11: wall-clock-flake-immune threshold
+            false,
         );
         let dv = result.expect("get_value should succeed for typed row");
         let variant = dv.value.expect("DataValue must carry a Variant");

--- a/src/opcua_topology_apply.rs
+++ b/src/opcua_topology_apply.rs
@@ -624,12 +624,25 @@ pub fn apply_diff_to_address_space(
     // Now register callbacks + update node_to_metric. These take the
     // inner SimpleNodeManagerImpl's callback-registry lock, not the
     // address-space lock — disjoint from Phase 3's hold.
+    // Issue #153: per-device SourceTimestamp mode, resolved from the new config
+    // once for the whole batch (the incremental path has no per-metric device
+    // handle otherwise).
+    let source_ts_by_device: HashMap<&str, bool> = new
+        .application_list
+        .iter()
+        .flat_map(|app| app.device_list.iter())
+        .map(|d| (d.device_id.as_str(), d.source_timestamp_server))
+        .collect();
     for a in &diff.added_metrics {
         let metric_node = metric_node_id(ns, &a.device_id, &a.metric_name);
         let storage_clone = storage.clone();
         let last_status_clone = last_status.clone();
         let device_id = a.device_id.clone();
         let chirpstack_metric_name = a.chirpstack_metric_name.clone();
+        let source_timestamp_server = source_ts_by_device
+            .get(a.device_id.as_str())
+            .copied()
+            .unwrap_or(false);
         manager
             .inner()
             .simple()
@@ -640,6 +653,7 @@ pub fn apply_diff_to_address_space(
                     device_id.clone(),
                     chirpstack_metric_name.clone(),
                     stale_threshold,
+                    source_timestamp_server,
                 )
             });
         node_to_metric.write().insert(
@@ -1221,6 +1235,7 @@ mod tests {
                     device_id: "dev-1".to_string(),
                     device_name: "Dev 1".to_string(),
                     stale_threshold_seconds: None,
+                    source_timestamp_server: false,
                     read_metric_list: vec![ReadMetric {
                         metric_name: "temp".to_string(),
                         chirpstack_metric_name: "t".to_string(),
@@ -1243,6 +1258,7 @@ mod tests {
             device_id: id.to_string(),
             device_name: name.to_string(),
             stale_threshold_seconds: None,
+            source_timestamp_server: false,
             read_metric_list: metrics,
             device_command_list: commands,
         }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -34,6 +34,8 @@ const MIGRATION_V010: &str = include_str!("../../migrations/v010_singleton_confi
 const MIGRATION_V011: &str = include_str!("../../migrations/v011_command_class.sql");
 const MIGRATION_V012: &str = include_str!("../../migrations/v012_device_stale_threshold.sql");
 const MIGRATION_V013: &str = include_str!("../../migrations/v013_error_events.sql");
+const MIGRATION_V014: &str =
+    include_str!("../../migrations/v014_device_source_timestamp.sql");
 
 /// Run all pending migrations based on current schema version.
 ///
@@ -70,7 +72,7 @@ pub fn run_migrations(conn: &Connection) -> Result<(), OpcGwError> {
 
     // Latest available schema version
     #[allow(dead_code)]
-    const LATEST_VERSION: u32 = 13;
+    const LATEST_VERSION: u32 = 14;
 
     // Apply migrations in order
     if current_version < 1 {
@@ -379,6 +381,28 @@ pub fn run_migrations(conn: &Connection) -> Result<(), OpcGwError> {
         info!(version = 13, "Applied migration v013_error_events");
     }
 
+    if current_version < 14 {
+        debug!("Applying migration v014_device_source_timestamp");
+
+        conn.execute_batch(MIGRATION_V014)
+            .map_err(|e| {
+                OpcGwError::Database(format!(
+                    "Failed to execute migration v014_device_source_timestamp: {}",
+                    e
+                ))
+            })?;
+
+        conn.pragma_update(None, "user_version", 14u32.to_string())
+            .map_err(|e| {
+                OpcGwError::Database(format!(
+                    "Failed to set schema version to 14: {}",
+                    e
+                ))
+            })?;
+
+        info!(version = 14, "Applied migration v014_device_source_timestamp");
+    }
+
     // Verify final version
     let final_version: u32 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
@@ -486,7 +510,7 @@ mod tests {
         let version: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("Failed to read version");
-        assert_eq!(version, 13, "Schema version should be 13 (latest — G-4 error_events table)");
+        assert_eq!(version, 14, "Schema version should be 14 (latest — issue #153 source_timestamp_server)");
 
         // Verify tables were created (excluding sqlite_sequence which is created automatically for AUTOINCREMENT)
         let table_count: i32 = conn
@@ -515,7 +539,7 @@ mod tests {
         let version: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("Failed to read version");
-        assert_eq!(version, 13, "Version should still be 13 (latest)");
+        assert_eq!(version, 14, "Version should still be 14 (latest)");
 
         // Cleanup
         let _ = fs::remove_file(&path);
@@ -753,7 +777,7 @@ mod tests {
         let post_version: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("Failed to read post-migration version");
-        assert_eq!(post_version, 13, "Post-upgrade version must be 13 (v006 → v007 → v008 → v009 → v010 → v011 → v012 → v013 in one pass)");
+        assert_eq!(post_version, 14, "Post-upgrade version must be 14 (v006 → … → v013 → v014 in one pass)");
 
         // Row counts preserved
         let mv_count: i32 = conn
@@ -1530,7 +1554,7 @@ mod tests {
         let version: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 13, "run_migrations must have advanced user_version to 13 (v008 + v009 + v010 + v011 + v012 + v013)");
+        assert_eq!(version, 14, "run_migrations must have advanced user_version to 14 (v008 + v009 + v010 + v011 + v012 + v013 + v014)");
 
         // Sanity: row counts preserved through the recreate
         let mv_count: i32 = conn
@@ -1664,8 +1688,8 @@ mod tests {
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
         assert_eq!(
-            version, 13,
-            "run_migrations must advance v006 -> v013 in a single call (real \
+            version, 14,
+            "run_migrations must advance v006 -> v014 in a single call (real \
              operator upgrade path)"
         );
 
@@ -1804,7 +1828,7 @@ mod tests {
         let version: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("read version");
-        assert_eq!(version, 13, "fresh DB must land at v013 (G-4 error_events table)");
+        assert_eq!(version, 14, "fresh DB must land at v014 (issue #153 source_timestamp_server)");
 
         for table in &["applications", "devices", "metrics", "commands"] {
             let exists: bool = conn
@@ -1834,7 +1858,7 @@ mod tests {
         let version: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("read version");
-        assert_eq!(version, 13, "version must stay at 13 (latest) after second run");
+        assert_eq!(version, 14, "version must stay at 14 (latest) after second run");
 
         let _ = fs::remove_file(&path);
     }
@@ -1938,7 +1962,7 @@ mod tests {
         let version: u32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("read version");
-        assert_eq!(version, 13, "version must stay at 13 (latest) after second run");
+        assert_eq!(version, 14, "version must stay at 14 (latest) after second run");
 
         let _ = fs::remove_file(&path);
     }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -2673,14 +2673,17 @@ impl SqliteBackend {
         let now = format_rfc3339(&Utc::now());
         conn.execute(
             "INSERT INTO devices \
-             (application_id, device_id, device_name, stale_threshold_seconds, created_at, updated_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+             (application_id, device_id, device_name, stale_threshold_seconds, \
+              source_timestamp_server, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             params![
                 application_id,
                 device.device_id,
                 device.device_name,
                 // Story E-1 (E-1b, #132): persist the per-device stale threshold.
                 device.stale_threshold_seconds.map(|v| v as i64),
+                // Issue #153: persist the per-device SourceTimestamp mode.
+                device.source_timestamp_server as i64,
                 now,
                 now
             ],
@@ -3116,11 +3119,12 @@ impl SqliteBackend {
         // ── devices ─────────────────────────────────────────────────────────
         let mut stmt = conn
             .prepare(
-                "SELECT application_id, device_id, device_name, stale_threshold_seconds \
+                "SELECT application_id, device_id, device_name, stale_threshold_seconds, \
+                 source_timestamp_server \
                  FROM devices ORDER BY application_id, device_id",
             )
             .map_err(|e| OpcGwError::Database(format!("prepare devices: {}", e)))?;
-        let dev_rows: Vec<(String, String, String, Option<u64>)> = stmt
+        let dev_rows: Vec<(String, String, String, Option<u64>, bool)> = stmt
             .query_map([], |row| {
                 let application_id = row.get::<_, String>(0)?;
                 let device_id = row.get::<_, String>(1)?;
@@ -3142,7 +3146,16 @@ impl SqliteBackend {
                         None
                     }
                 });
-                Ok((application_id, device_id, device_name, stale_threshold))
+                // Issue #153: per-device SourceTimestamp mode (0 = device time,
+                // 1 = server now). Column is NOT NULL DEFAULT 0 (v014).
+                let source_timestamp_server = row.get::<_, i64>(4)? != 0;
+                Ok((
+                    application_id,
+                    device_id,
+                    device_name,
+                    stale_threshold,
+                    source_timestamp_server,
+                ))
             })
             .map_err(|e| OpcGwError::Database(format!("query devices: {}", e)))?
             .collect::<Result<_, _>>()
@@ -3205,7 +3218,7 @@ impl SqliteBackend {
         for (app_id, app_name) in app_rows {
             let mut devices: Vec<ChirpstackDevice> = Vec::new();
 
-            for (dev_app_id, dev_id, dev_name, dev_stale) in &dev_rows {
+            for (dev_app_id, dev_id, dev_name, dev_stale, dev_source_ts_server) in &dev_rows {
                 if dev_app_id != &app_id {
                     continue;
                 }
@@ -3241,6 +3254,7 @@ impl SqliteBackend {
                     device_id: dev_id.clone(),
                     device_name: dev_name.clone(),
                     stale_threshold_seconds: *dev_stale,
+                    source_timestamp_server: *dev_source_ts_server,
                     read_metric_list: metrics,
                     device_command_list: if commands.is_empty() {
                         None
@@ -3652,6 +3666,9 @@ impl SqliteBackend {
         // None → NULL column → device uses the global [opcua] default.
         // Persisted in the v012 `devices.stale_threshold_seconds` column.
         stale_threshold_seconds: Option<u64>,
+        // Issue #153: per-device SourceTimestamp mode. Persisted in the v014
+        // `devices.source_timestamp_server` column (0 = device time, 1 = now()).
+        source_timestamp_server: bool,
     ) -> Result<(), OpcGwError> {
         let conn = self.pool.checkout(Duration::from_secs(5)).map_err(|e| {
             error!(error = %e, "Pool checkout timeout for insert_device_with_metrics");
@@ -3664,13 +3681,15 @@ impl SqliteBackend {
             let now = format_rfc3339(&Utc::now());
             conn.execute(
                 "INSERT INTO devices \
-                 (application_id, device_id, device_name, stale_threshold_seconds, created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                 (application_id, device_id, device_name, stale_threshold_seconds, \
+                  source_timestamp_server, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 params![
                     application_id,
                     device_id,
                     device_name,
                     stale_threshold_seconds.map(|v| v as i64),
+                    source_timestamp_server as i64,
                     now,
                     now
                 ],
@@ -3734,6 +3753,8 @@ impl SqliteBackend {
         // Story G-3 (#132): per-device stale threshold (seconds); None → NULL
         // (use the global [opcua] default). Written in the same EXCLUSIVE txn.
         stale_threshold_seconds: Option<u64>,
+        // Issue #153: per-device SourceTimestamp mode (v014 column).
+        source_timestamp_server: bool,
     ) -> Result<(), OpcGwError> {
         let conn = self.pool.checkout(Duration::from_secs(5)).map_err(|e| {
             error!(error = %e, "Pool checkout timeout for update_device_name_and_metrics");
@@ -3745,11 +3766,13 @@ impl SqliteBackend {
         let result: Result<(), OpcGwError> = (|| {
             let now = format_rfc3339(&Utc::now());
             conn.execute(
-                "UPDATE devices SET device_name = ?1, stale_threshold_seconds = ?2, updated_at = ?3 \
-                 WHERE application_id = ?4 AND device_id = ?5",
+                "UPDATE devices SET device_name = ?1, stale_threshold_seconds = ?2, \
+                 source_timestamp_server = ?3, updated_at = ?4 \
+                 WHERE application_id = ?5 AND device_id = ?6",
                 params![
                     new_name,
                     stale_threshold_seconds.map(|v| v as i64),
+                    source_timestamp_server as i64,
                     now,
                     application_id,
                     device_id
@@ -3856,14 +3879,17 @@ impl SqliteBackend {
                 for device in &app.device_list {
                     conn.execute(
                         "INSERT INTO devices \
-                         (application_id, device_id, device_name, stale_threshold_seconds, created_at, updated_at) \
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                         (application_id, device_id, device_name, stale_threshold_seconds, \
+                          source_timestamp_server, created_at, updated_at) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                         params![
                             app.application_id,
                             device.device_id,
                             device.device_name,
                             // Story E-1 (E-1b, #132): persist a TOML-seeded per-device threshold.
                             device.stale_threshold_seconds.map(|v| v as i64),
+                            // Issue #153: persist the TOML-seeded SourceTimestamp mode.
+                            device.source_timestamp_server as i64,
                             now,
                             now
                         ],
@@ -4090,13 +4116,16 @@ impl SqliteBackend {
                 for device in &app.device_list {
                     conn.execute(
                         "INSERT INTO devices \
-                         (application_id, device_id, device_name, stale_threshold_seconds, created_at, updated_at) \
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                         (application_id, device_id, device_name, stale_threshold_seconds, \
+                          source_timestamp_server, created_at, updated_at) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                         params![
                             app.application_id,
                             device.device_id,
                             device.device_name,
                             device.stale_threshold_seconds.map(|v| v as i64),
+                            // Issue #153: persist the imported SourceTimestamp mode.
+                            device.source_timestamp_server as i64,
                             now,
                             now
                         ],

--- a/src/storage/sqlite_tests.rs
+++ b/src/storage/sqlite_tests.rs
@@ -3949,6 +3949,7 @@
             device_id: id.to_string(),
             device_name: name.to_string(),
             stale_threshold_seconds: None,
+            source_timestamp_server: false,
             read_metric_list: vec![],
             device_command_list: None,
         }
@@ -4210,6 +4211,48 @@
         assert_eq!(
             d2l.stale_threshold_seconds, None,
             "absent override must load as None (use global)"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_issue153_source_timestamp_server_roundtrip() {
+        let path = temp_backend_path();
+        let b = SqliteBackend::new(&path).unwrap();
+        b.insert_application(&make_app("app-1", "App")).unwrap();
+        // Device WITH the server-timestamp flag on.
+        let mut d1 = make_device("dev-1", "Dev1");
+        d1.source_timestamp_server = true;
+        b.insert_device("app-1", &d1).unwrap();
+        // Device without it → default false.
+        b.insert_device("app-1", &make_device("dev-2", "Dev2"))
+            .unwrap();
+
+        let loaded = b.load_all_applications_config().unwrap();
+        let devs = &loaded[0].device_list;
+        let d1l = devs.iter().find(|d| d.device_id == "dev-1").unwrap();
+        let d2l = devs.iter().find(|d| d.device_id == "dev-2").unwrap();
+        assert!(
+            d1l.source_timestamp_server,
+            "per-device source_timestamp_server=true must round-trip through SQLite (#153)"
+        );
+        assert!(
+            !d2l.source_timestamp_server,
+            "absent flag must load as false (device report time)"
+        );
+
+        // Flip it via the CRUD update path and re-load.
+        b.update_device_name_and_metrics("app-1", "dev-1", "Dev1", &d1.read_metric_list, None, false)
+            .unwrap();
+        let reloaded = b.load_all_applications_config().unwrap();
+        let d1r = reloaded[0]
+            .device_list
+            .iter()
+            .find(|d| d.device_id == "dev-1")
+            .unwrap();
+        assert!(
+            !d1r.source_timestamp_server,
+            "CRUD update must be able to clear the flag back to device time (#153)"
         );
         let _ = fs::remove_file(&path);
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -467,6 +467,11 @@ pub struct DeviceView {
     /// top-level `stale_threshold_secs` global. The client freshness band uses
     /// this when set, falling back to the global default otherwise.
     pub stale_threshold_seconds: Option<u64>,
+    /// Issue #153: per-device SourceTimestamp mode. `true` = opcgw stamps served
+    /// values with the gateway's current time (`now()`); `false` (default) = the
+    /// device's real report time. Fixes stale-quality overlays in SCADA clients
+    /// (e.g. Ignition) on slow-cadence tags.
+    pub source_timestamp_server: bool,
     pub metrics: Vec<MetricView>,
 }
 
@@ -726,6 +731,7 @@ pub async fn api_devices(
                         device_id: dev.device_id.clone(),
                         device_name: dev.device_name.clone(),
                         stale_threshold_seconds: dev.stale_threshold_seconds,
+                        source_timestamp_server: dev.source_timestamp_server,
                         metrics,
                     }
                 })
@@ -1973,6 +1979,11 @@ pub struct CreateDeviceRequest {
     /// Absent/null → use the global default. Validated to the band `(0, 86400]`.
     #[serde(default)]
     pub stale_threshold_seconds: Option<u64>,
+    /// Issue #153: per-device SourceTimestamp mode. `true` = stamp served values
+    /// with the gateway's current time (`now()`) so SCADA clients keep the tag
+    /// `Good`; `false`/absent (default) = the device's real report time.
+    #[serde(default)]
+    pub source_timestamp_server: bool,
 }
 
 /// `PUT /api/applications/:application_id/devices/:device_id` request body.
@@ -2129,6 +2140,9 @@ pub struct DeviceResponse {
     /// Story G-3 (#132): per-device stale threshold (seconds); `null` = the
     /// device uses the global `[opcua].stale_threshold_seconds` default.
     pub stale_threshold_seconds: Option<u64>,
+    /// Issue #153: per-device SourceTimestamp mode (`true` = server `now()`,
+    /// `false` = device report time).
+    pub source_timestamp_server: bool,
 }
 
 /// One row in [`DeviceResponse::read_metric_list`]. `metric_type` is
@@ -2278,6 +2292,7 @@ pub async fn get_device(
         device_name: dev.device_name.clone(),
         read_metric_list,
         stale_threshold_seconds: dev.stale_threshold_seconds,
+        source_timestamp_server: dev.source_timestamp_server,
     }))
 }
 
@@ -2432,6 +2447,7 @@ pub async fn create_device(
             &body.device_name,
             &read_metrics,
             body.stale_threshold_seconds,
+            body.source_timestamp_server,
         )
         .map_err(|e| sqlite_crud_error(e, "device", "create_device", &addr))?;
 
@@ -2505,6 +2521,7 @@ pub async fn create_device(
             device_name: body.device_name,
             read_metric_list,
             stale_threshold_seconds: body.stale_threshold_seconds,
+            source_timestamp_server: body.source_timestamp_server,
         }),
     ))
 }
@@ -2558,6 +2575,9 @@ pub async fn update_device(
     // Story G-3 (#132): PUT-replace semantics — absent or null clears the
     // per-device override (device falls back to the global default).
     let mut new_threshold: Option<u64> = None;
+    // Issue #153: PUT-replace semantics — absent/false = device report time,
+    // true = server now(). The web form always sends this field explicitly.
+    let mut new_source_ts_server = false;
     for (k, v) in obj {
         match k.as_str() {
             "device_name" => {
@@ -2631,6 +2651,28 @@ pub async fn update_device(
                     new_threshold = Some(n);
                 }
             }
+            "source_timestamp_server" => {
+                // Issue #153: boolean per-device SourceTimestamp mode.
+                new_source_ts_server = v.as_bool().ok_or_else(|| {
+                    warn!(
+                        event = "device_crud_rejected",
+                        reason = "validation",
+                        field = "source_timestamp_server",
+                        application_id = %application_id,
+                        device_id = %device_id,
+                        source_ip = %addr.ip(),
+                        "PUT body field 'source_timestamp_server' must be a boolean"
+                    );
+                    (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse::with_hint(
+                            "source_timestamp_server must be a boolean",
+                            "true = stamp served values with server now(); false/omit = device report time",
+                        )),
+                    )
+                        .into_response()
+                })?;
+            }
             "device_id" => {
                 warn!(
                     event = "device_crud_rejected",
@@ -2674,7 +2716,7 @@ pub async fn update_device(
                         // newlines into the response body (parallel
                         // to the iter-1 B-H5 fix in audit-log emission).
                         format!("PUT body contains unknown field {other:?}"),
-                        "PUT accepts `device_name`, `read_metric_list`, and optional `stale_threshold_seconds` (PUT-replace: omit or send null to clear the per-device override back to the global default)",
+                        "PUT accepts `device_name`, `read_metric_list`, and optional `stale_threshold_seconds` / `source_timestamp_server` (PUT-replace: omit or send null to clear the per-device override back to the global default)",
                     )),
                 )
                     .into_response());
@@ -2843,6 +2885,7 @@ pub async fn update_device(
             &device_name,
             &new_metrics,
             new_threshold,
+            new_source_ts_server,
         )
         .map_err(|e| sqlite_crud_error(e, "device", "update_device", &addr))?;
 
@@ -2908,6 +2951,7 @@ pub async fn update_device(
         device_name,
         read_metric_list: read_metric_list_resp,
         stale_threshold_seconds: new_threshold,
+        source_timestamp_server: new_source_ts_server,
     }))
 }
 
@@ -5057,6 +5101,7 @@ mod tests {
                         device_id: format!("dev-{i}-{j}"),
                         device_name: format!("Dev {i}-{j}"),
                         stale_threshold_seconds: None,
+                        source_timestamp_server: false,
                         metrics: vec![],
                     })
                     .collect();
@@ -5463,6 +5508,7 @@ mod tests {
             device_id: id.to_string(),
             device_name: name.to_string(),
             stale_threshold_seconds: None,
+            source_timestamp_server: false,
             metrics: metrics
                 .iter()
                 .map(|(n, t)| crate::web::MetricSpec {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -111,6 +111,10 @@ pub struct DeviceSummary {
     /// on the snapshot so `/api/devices` can surface it per device for the
     /// client freshness band.
     pub stale_threshold_seconds: Option<u64>,
+    /// Issue #153: per-device SourceTimestamp mode (`true` = server `now()`,
+    /// `false` = device report time). Surfaced per device so the config UI can
+    /// render the checkbox state.
+    pub source_timestamp_server: bool,
     /// Configured metric specs in TOML-declaration order. Adding a new
     /// metric to the bottom of the TOML list shows up at the bottom of
     /// the row in the dashboard — no random hashmap reordering.
@@ -229,6 +233,7 @@ impl DashboardConfigSnapshot {
                             device_id: dev.device_id.clone(),
                             device_name: dev.device_name.clone(),
                             stale_threshold_seconds: dev.stale_threshold_seconds,
+                            source_timestamp_server: dev.source_timestamp_server,
                             metrics,
                         }
                     })
@@ -972,6 +977,7 @@ mod tests {
                     device_id: format!("dev-{name}-{i}"),
                     device_name: format!("Device {i}"),
                     stale_threshold_seconds: None,
+                    source_timestamp_server: false,
                     read_metric_list: vec![ReadMetric {
                         metric_name: "temperature".to_string(),
                         chirpstack_metric_name: "temp".to_string(),
@@ -1025,6 +1031,7 @@ mod tests {
                 device_id: "dev-empty".to_string(),
                 device_name: "Empty Device".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 read_metric_list: vec![],
                 device_command_list: None,
             }],
@@ -1050,6 +1057,7 @@ mod tests {
                 device_id: "dev-1".to_string(),
                 device_name: "Device 1".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 read_metric_list: vec![
                     ReadMetric {
                         metric_name: "temperature".to_string(),
@@ -1090,6 +1098,7 @@ mod tests {
                 device_id: "dev-1".to_string(),
                 device_name: "Device 1".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 read_metric_list: vec![
                     // Empty string -> None.
                     ReadMetric {

--- a/src/web/test_support.rs
+++ b/src/web/test_support.rs
@@ -57,6 +57,7 @@ pub fn make_test_reload_handle_and_writer_with_apps(
                     &dev.device_name,
                     &dev.read_metric_list,
                     dev.stale_threshold_seconds,
+                    dev.source_timestamp_server,
                 )
                 .unwrap_or(());
             if let Some(cmds) = &dev.device_command_list {
@@ -86,6 +87,7 @@ pub fn stub_app_config() -> AppConfig {
             device_id: "dev-1".to_string(),
             device_name: "Dev One".to_string(),
             stale_threshold_seconds: None,
+            source_timestamp_server: false,
             read_metric_list: vec![ReadMetric {
                 metric_name: "temperature".to_string(),
                 chirpstack_metric_name: "temperature".to_string(),

--- a/static/config.js
+++ b/static/config.js
@@ -962,6 +962,18 @@
     mForm.appendChild(staleInput);
     var staleHelp = fieldHelp('device.stale_threshold_seconds', staleInput);
     if (staleHelp) mForm.appendChild(staleHelp);
+    // Issue #153: per-device OPC UA SourceTimestamp mode. Checked = opcgw stamps
+    // served values with the gateway's current time (now()) so SCADA clients
+    // (e.g. Ignition) that flag old source timestamps keep the tag Good.
+    var srcTsLabel = el('label', { class: 'checkbox-label' });
+    var srcTsInput = el('input', { type: 'checkbox' });
+    if (dev.source_timestamp_server) srcTsInput.checked = true;
+    srcTsLabel.appendChild(srcTsInput);
+    srcTsLabel.appendChild(document.createTextNode(
+      ' Use server time as OPC UA source timestamp (fixes stale/Uncertain quality in SCADA clients like Ignition for slow-cadence devices)'));
+    mForm.appendChild(srcTsLabel);
+    var srcTsHelp = fieldHelp('device.source_timestamp_server', srcTsInput);
+    if (srcTsHelp) mForm.appendChild(srcTsHelp);
     mForm.appendChild(el('h3', { text: 'Metric mappings' }));
     var metricContainer = el('div');
     (dev.read_metric_list || []).forEach(function (m) { buildMetricRow(m, metricContainer); });
@@ -995,6 +1007,8 @@
         read_metric_list: readMetricsFromContainer(metricContainer),
         // null clears the override (back to the global default); PUT-replace.
         stale_threshold_seconds: staleVal,
+        // Issue #153: per-device SourceTimestamp mode (checkbox).
+        source_timestamp_server: srcTsInput.checked,
       };
       try {
         var r = await fetch(devUrl, { method: 'PUT', credentials: 'include', headers: jsonHeaders(), body: JSON.stringify(payload) });

--- a/static/field-help.js
+++ b/static/field-help.js
@@ -88,6 +88,7 @@
 
     // Device / metric / command forms (config.js).
     'device.stale_threshold_seconds': { text: 'Optional per-device override of the global OPC UA stale threshold. Whole seconds in (0, 86400]. Leave empty to use the global [opcua].stale_threshold_seconds (default 120 s). Useful for slow sensors that would otherwise read Uncertain between uplinks.' },
+    'device.source_timestamp_server': { text: 'When checked, opcgw stamps this device\'s OPC UA values with the gateway\'s current time (now()) instead of the device\'s real report time. Leave unchecked (default) for strict OPC UA semantics. Check it only for SCADA clients (e.g. Ignition) that mark a tag Uncertain/Stale when the source timestamp is older than their window — common on slow-cadence LoRaWAN devices. The staleness quality still flips to Uncertain if the device genuinely stops reporting past its stale threshold.' },
     'metric.metric_name': { text: 'Display name of the variable in the OPC UA address space (what SCADA clients see).' },
     'metric.chirpstack_metric_name': { text: 'The exact field name from the ChirpStack decoded uplink (or device-profile measurement) to read. Must match ChirpStack exactly.' },
     'metric.metric_type': { text: 'OPC UA data type the value is exposed as: Float, Int, Bool, or String. The picker can infer this from the device profile or recent uplinks.' },

--- a/tests/opc_ua_connection_limit.rs
+++ b/tests/opc_ua_connection_limit.rs
@@ -210,6 +210,7 @@ fn test_config(port: u16, pki_dir: &std::path::Path, max_connections: usize) -> 
             device_list: vec![ChirpstackDevice {
                 device_name: "TestDevice".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 device_id: "0000000000000001".to_string(),
                 read_metric_list: vec![ReadMetric {
                     metric_name: "Temperature".to_string(),

--- a/tests/opc_ua_security_endpoints.rs
+++ b/tests/opc_ua_security_endpoints.rs
@@ -189,6 +189,7 @@ fn test_config(port: u16, pki_dir: &std::path::Path) -> AppConfig {
             device_list: vec![ChirpstackDevice {
                 device_name: "TestDevice".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 device_id: "0000000000000001".to_string(),
                 read_metric_list: vec![ReadMetric {
                     metric_name: "Temperature".to_string(),

--- a/tests/opcua_dynamic_address_space_apply.rs
+++ b/tests/opcua_dynamic_address_space_apply.rs
@@ -138,6 +138,7 @@ fn baseline_app_config(port: u16, pki_dir: &std::path::Path) -> AppConfig {
                 device_id: APPLY_DEVICE_BASELINE.to_string(),
                 device_name: APPLY_DEVICE_BASELINE.to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 read_metric_list: vec![ReadMetric {
                     metric_name: APPLY_METRIC_BASELINE.to_string(),
                     chirpstack_metric_name: APPLY_CHIRP_BASELINE.to_string(),
@@ -161,6 +162,7 @@ fn config_add_second_device(prev: &AppConfig) -> AppConfig {
         device_id: APPLY_DEVICE_NEW.to_string(),
         device_name: APPLY_DEVICE_NEW.to_string(),
         stale_threshold_seconds: None,
+        source_timestamp_server: false,
         read_metric_list: vec![ReadMetric {
             metric_name: APPLY_METRIC_NEW.to_string(),
             chirpstack_metric_name: APPLY_CHIRP_NEW.to_string(),

--- a/tests/opcua_dynamic_address_space_spike.rs
+++ b/tests/opcua_dynamic_address_space_spike.rs
@@ -101,6 +101,7 @@ fn dyn_spike_test_config(
         .map(|d| ChirpstackDevice {
             device_name: d.device_id.to_string(),
             stale_threshold_seconds: None,
+            source_timestamp_server: false,
             device_id: d.device_id.to_string(),
             read_metric_list: vec![ReadMetric {
                 metric_name: d.metric_name.to_string(),

--- a/tests/opcua_history.rs
+++ b/tests/opcua_history.rs
@@ -135,6 +135,7 @@ fn history_test_config(
             device_list: vec![ChirpstackDevice {
                 device_name: "HistoryDevice".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 device_id: TEST_DEVICE_ID.to_string(),
                 read_metric_list: vec![ReadMetric {
                     metric_name: TEST_METRIC_OPCUA_NAME.to_string(),
@@ -847,6 +848,7 @@ async fn test_history_read_multi_device_no_node_id_collision_issue_99() {
                 ChirpstackDevice {
                     device_name: "DeviceA".to_string(),
                     stale_threshold_seconds: None,
+                    source_timestamp_server: false,
                     device_id: DEVICE_A_ID.to_string(),
                     read_metric_list: vec![ReadMetric {
                         metric_name: SHARED_METRIC_OPCUA_NAME.to_string(),
@@ -859,6 +861,7 @@ async fn test_history_read_multi_device_no_node_id_collision_issue_99() {
                 ChirpstackDevice {
                     device_name: "DeviceB".to_string(),
                     stale_threshold_seconds: None,
+                    source_timestamp_server: false,
                     device_id: DEVICE_B_ID.to_string(),
                     read_metric_list: vec![ReadMetric {
                         metric_name: SHARED_METRIC_OPCUA_NAME.to_string(),

--- a/tests/opcua_subscription_spike.rs
+++ b/tests/opcua_subscription_spike.rs
@@ -249,6 +249,7 @@ fn spike_test_config(port: u16, pki_dir: &std::path::Path, max_connections: usiz
             device_list: vec![ChirpstackDevice {
                 device_name: "SpikeDevice".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 device_id: SPIKE_DEVICE_ID.to_string(),
                 read_metric_list: vec![ReadMetric {
                     metric_name: SPIKE_METRIC_OPCUA_NAME.to_string(),

--- a/tests/sqlite_application_list_on_restart.rs
+++ b/tests/sqlite_application_list_on_restart.rs
@@ -69,7 +69,7 @@ fn sqlite_application_list_overrides_config_toml_seed_on_load() {
         },
     ];
     backend
-        .insert_device_with_metrics(APP_ID, DEVICE_ID, "lsn50-magasin", &metrics, None)
+        .insert_device_with_metrics(APP_ID, DEVICE_ID, "lsn50-magasin", &metrics, None, false)
         .expect("insert device with metrics");
 
     // --- load_all_applications_config round-trips the topology (the data

--- a/tests/sqlite_config_migration.rs
+++ b/tests/sqlite_config_migration.rs
@@ -502,6 +502,7 @@ fn migration_large_inventory_completes_in_time() {
                     device_id: format!("app-{app_i:03}-dev-{dev_j:02}"),
                     device_name: format!("Device {dev_j}"),
                     stale_threshold_seconds: None,
+                    source_timestamp_server: false,
                     read_metric_list: (0..3)
                         .map(|met_k| ReadMetric {
                             metric_name: format!("metric-{met_k}"),
@@ -599,6 +600,7 @@ fn migration_duplicate_application_id_is_rejected() {
             device_id: format!("dev-{id}"),
             device_name: "Dev".to_string(),
             stale_threshold_seconds: None,
+            source_timestamp_server: false,
             read_metric_list: vec![ReadMetric {
                 metric_name: "m".to_string(),
                 chirpstack_metric_name: "m".to_string(),

--- a/tests/web_application_crud.rs
+++ b/tests/web_application_crud.rs
@@ -284,7 +284,7 @@ async fn spawn_fixture(seed_toml: &str) -> CrudFixture {
         }).unwrap_or(());
         for dev in &app.device_list {
             sqlite_backend.insert_device_with_metrics(
-                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds,
+                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds, dev.source_timestamp_server,
             ).unwrap_or(());
             if let Some(cmds) = &dev.device_command_list {
                 for cmd in cmds {

--- a/tests/web_command_crud.rs
+++ b/tests/web_command_crud.rs
@@ -227,7 +227,7 @@ async fn spawn_fixture(seed_toml: &str) -> CrudFixture {
         }).unwrap_or(());
         for dev in &app.device_list {
             sqlite_backend.insert_device_with_metrics(
-                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds,
+                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds, dev.source_timestamp_server,
             ).unwrap_or(());
             if let Some(cmds) = &dev.device_command_list {
                 for cmd in cmds {

--- a/tests/web_dashboard.rs
+++ b/tests/web_dashboard.rs
@@ -656,6 +656,7 @@ async fn api_devices_returns_json_with_expected_shape_when_authed() {
                     device_name: "Device One".to_string(),
                     // Story G-3 (#132): per-device override surfaced on /api/devices.
                     stale_threshold_seconds: Some(600),
+                    source_timestamp_server: false,
                     metrics: vec![opcgw::web::MetricSpec {
                         metric_name: "temperature".to_string(),
                         chirpstack_metric_name: "temperature".to_string(),
@@ -668,6 +669,7 @@ async fn api_devices_returns_json_with_expected_shape_when_authed() {
                     device_name: "Device Two".to_string(),
                     // No per-device override → null on the wire (uses global).
                     stale_threshold_seconds: None,
+                    source_timestamp_server: false,
                     metrics: vec![],
                 },
             ],
@@ -786,6 +788,7 @@ async fn api_devices_emits_typed_value_and_unit_per_variant() {
                 device_id: "dev-a6".to_string(),
                 device_name: "A-6 Device".to_string(),
                 stale_threshold_seconds: None,
+                source_timestamp_server: false,
                 metrics: vec![
                     opcgw::web::MetricSpec {
                         metric_name: "temperature".to_string(),

--- a/tests/web_device_crud.rs
+++ b/tests/web_device_crud.rs
@@ -269,7 +269,7 @@ async fn spawn_fixture(seed_toml: &str) -> CrudFixture {
         }).unwrap_or(());
         for dev in &app.device_list {
             sqlite_backend.insert_device_with_metrics(
-                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds,
+                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds, dev.source_timestamp_server,
             ).unwrap_or(());
             if let Some(cmds) = &dev.device_command_list {
                 for cmd in cmds {

--- a/tests/web_duplicate_prevention.rs
+++ b/tests/web_duplicate_prevention.rs
@@ -255,7 +255,7 @@ async fn spawn_fixture(seed_toml: &str) -> CrudFixture {
         }).unwrap_or(());
         for dev in &app.device_list {
             sqlite_backend.insert_device_with_metrics(
-                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds,
+                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds, dev.source_timestamp_server,
             ).unwrap_or(());
             if let Some(cmds) = &dev.device_command_list {
                 for cmd in cmds {

--- a/tests/web_inventory_drift.rs
+++ b/tests/web_inventory_drift.rs
@@ -232,7 +232,7 @@ async fn spawn_fixture(seed_toml: &str) -> DriftFixture {
         }).unwrap_or(());
         for dev in &app.device_list {
             sqlite_backend.insert_device_with_metrics(
-                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds,
+                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds, dev.source_timestamp_server,
             ).unwrap_or(());
             if let Some(cmds) = &dev.device_command_list {
                 for cmd in cmds {

--- a/tests/web_picker.rs
+++ b/tests/web_picker.rs
@@ -205,7 +205,7 @@ async fn spawn_fixture(seed_toml: &str) -> PickerFixture {
         }).unwrap_or(());
         for dev in &app.device_list {
             sqlite_backend.insert_device_with_metrics(
-                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds,
+                &app.application_id, &dev.device_id, &dev.device_name, &dev.read_metric_list, dev.stale_threshold_seconds, dev.source_timestamp_server,
             ).unwrap_or(());
             if let Some(cmds) = &dev.device_command_list {
                 for cmd in cmds {


### PR DESCRIPTION
## Summary

Adds a per-device **`source_timestamp_server`** flag so opcgw can stamp served OPC UA values with the gateway's current time (`now()`) instead of the device's real report time.

Fixes SCADA clients — notably **Ignition 8.3** — that overlay a *Stale / Uncertain* quality on any value whose `SourceTimestamp` is older than a client-side window. Slow-cadence LoRaWAN devices (e.g. a 20-min uplink interval) otherwise read `Uncertain` between uplinks even though opcgw returns `Good`, and raising `stale_threshold_seconds` does **not** help — that knob only governs opcgw's own `StatusCode`, not the client's timestamp interpretation.

### How it was diagnosed
Field-diagnosed on the panoramix deployment by connecting an OPC UA client directly: **all 515 nodes served `Good`** on both reads and subscriptions, so the Uncertain was entirely client-side. The discriminator was cadence — `meteo02` (~60 s) stayed Good while the ~20-min building devices flapped.

## Behaviour
- Default **`false`** = device report time (strict OPC UA semantics; unchanged pre-#153).
- **`true`** = server `now()` as `SourceTimestamp` (same instant as `ServerTimestamp`).
- Staleness `StatusCode` is **unaffected** — a device that genuinely stops reporting past its stale threshold still flips to `Uncertain`, so dead-device detection is preserved.

## Surface
- **Config**: `source_timestamp_server` on `[[application.device]]` (`ChirpstackDevice`).
- **OPC UA**: resolved per-device in the read callback (`get_value`) and in the incremental topology-apply path.
- **SQLite**: schema migration **v014** adds `devices.source_timestamp_server`; load + persist + CRUD create/update round-trip the column.
- **Web**: device CRUD DTOs + `PUT` field-parser + a **checkbox** in Config → device, with contextual field-help.
- **Tests**: `get_value` server-mode behaviour, storage round-trip, CRUD clear-back; schema-version assertions bumped to 14.
- **Docs**: README, `config/config.toml`, `docs/configuration.md`, DocBook user manual, CHANGELOG.

## Validation
- `cargo test` — 1415+ tests, **0 failed**.
- `cargo clippy --all-targets -- -D warnings` — **clean**.
- DocBook XML well-formed (`xmllint`).

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)