### PR TITLE
chore: async-opcua 0.19 + dependency refresh (Batch A) + MSRV 1.95 (#165, #159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.94.0
+          toolchain: 1.95.0
 
       - uses: Swatinem/rust-cache@v2
 
@@ -39,7 +39,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.94.0
+          toolchain: 1.95.0
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -58,7 +58,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.94.0
+          toolchain: 1.95.0
 
       - uses: Swatinem/rust-cache@v2
 
@@ -79,7 +79,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.94.0
+          toolchain: 1.95.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -117,7 +117,7 @@ jobs:
           tags: ${{ steps.meta-ghcr.outputs.tags }}
           labels: ${{ steps.meta-ghcr.outputs.labels }}
           build-args: |
-            RUST_VERSION=1.94.0
+            RUST_VERSION=1.95.0
             APP_NAME=opcgw
 
       - name: Build and push to Docker Hub
@@ -132,7 +132,7 @@ jobs:
           tags: ${{ steps.meta-hub.outputs.tags }}
           labels: ${{ steps.meta-hub.outputs.labels }}
           build-args: |
-            RUST_VERSION=1.94.0
+            RUST_VERSION=1.95.0
             APP_NAME=opcgw
 
       - name: Sync Docker Hub repository description

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ The build script (`build.rs`) compiles Protocol Buffer definitions from `proto/c
 ## Code Conventions
 
 - SPDX license headers (MIT OR Apache-2.0) and copyright `(c) [2024] Guy Corbaz` in each source file.
-- Rust 2021 edition, minimum rustc 1.87.0.
+- Rust 2021 edition, minimum rustc 1.95.0.
 - Custom error type `OpcGwError` in `utils.rs` using `thiserror`.
 - Extensive doc comments on all public items.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chirpstack_api = "4.17.0"
 prost = "0.14"
 prost-types = "0.14"
 tonic-prost = "0.14"
-async-opcua = { version = "0.17.1", features = ["server"] }
+async-opcua = { version = "0.19.0", features = ["server"] }
 constant_time_eq = "0.3"
 hmac = "0.12"
 # Story 7-2 + 9-1: per-process HMAC keying via OS RNG. Pinned to 0.2
@@ -90,7 +90,7 @@ serial_test = "3"
 # release build) and shrink the release binary. Tests + examples have access
 # to dev-dependencies, so `cargo test` and `cargo build --examples`
 # transparently see both server + client features merged.
-async-opcua = { version = "0.17.1", features = ["client"] }
+async-opcua = { version = "0.19.0", features = ["client"] }
 # Story 9-1 integration tests: HTTP client for the embedded web server.
 # Dev-only — no inbound HTTP client in a release build.
 reqwest = { version = "0.12", default-features = false, features = ["http2", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A Chirpstack to opc ua gateway"
 readme = "README.md"
 keywords = ["scada","gateway","opc_ua","chirpstack"]
 license = "MIT OR Apache-2.0"
-rust-version = "1.94.0"
+rust-version = "1.95.0"
 edition = "2021"
 categories = ["science"]
 publish = false # for now, until a running version is available
@@ -54,12 +54,12 @@ dashmap = "6.1"
 
 # Dependencies for later stories (added now, not yet used)
 tokio-util = "0.7.18"
-rusqlite = { version = "0.38.0", features = ["bundled"] }
+rusqlite = { version = "0.40.1", features = ["bundled"] }
 uuid = { version = "1.10.0", features = ["v4", "serde"] }
 
 # Story 9-1: embedded Axum web server for FR50 / NFR11 / NFR12 / FR41.
 axum = "0.8"
-tower-http = { version = "0.6", features = ["fs", "set-header"] }
+tower-http = { version = "0.7", features = ["fs", "set-header"] }
 base64 = "0.22"
 # Story D-2 (2026-05-27): removed `toml_edit = "0.25.11"`. Story C-6 (2026-05-26)
 # decommissioned the SIGHUP + TOML round-trip mutation path (Story 9-4's
@@ -93,7 +93,7 @@ serial_test = "3"
 async-opcua = { version = "0.19.0", features = ["client"] }
 # Story 9-1 integration tests: HTTP client for the embedded web server.
 # Dev-only — no inbound HTTP client in a release build.
-reqwest = { version = "0.12", default-features = false, features = ["http2", "json"] }
+reqwest = { version = "0.13", default-features = false, features = ["http2", "json"] }
 # Story 9-1 unit tests: tower::ServiceExt::oneshot for in-process Axum
 # middleware testing without binding a TCP listener.
 tower = { version = "0.5", features = ["util"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Operator-side: chown 10001:10001 ./log ./config ./pki BEFORE the first `docker compose up`
 # so the gateway can write log files + read+write SQLite database + read PKI.
 
-ARG RUST_VERSION=1.94.0
+ARG RUST_VERSION=1.95.0
 ARG APP_NAME=opcgw
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ChirpStack Server (LoRaWAN) ──→ opcgw Gateway ──→ OPC UA Clients (SC
 
 ## Installation
 
-### From Source (Rust 1.94.0+)
+### From Source (Rust 1.95.0+)
 
 ```bash
 git clone https://github.com/guycorbaz/opcgw.git
@@ -444,7 +444,7 @@ Both components share thread-safe in-memory storage via `Arc<Mutex<Storage>>`.
 
 ## Technology Stack
 
-- **Language**: Rust 1.94.0+ with async/await
+- **Language**: Rust 1.95.0+ with async/await
 - **Protocols**: gRPC for ChirpStack, OPC UA 1.04 for industrial clients
 - **Storage**: SQLite (WAL mode) for metric values, history, command queue, and configuration; in-memory cache for current values
 - **Logging**: Tokio-tracing with structured fields, a single retention-capped daily log file, and a stderr console layer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,7 +278,7 @@ POST /api/applications/:id/devices
 
 ## Deployment
 
-**Docker:** Multi-stage build (`rust:1.94` builder → `ubuntu:24.04` runtime, non-root user `opcgw` UID 10001). Exposes ports 4840 (OPC UA) and 8080 (web UI). Mounts `log/`, `config/`, `pki/`, `data/` as volumes (the `data/` mount is required — it holds the authoritative SQLite database).
+**Docker:** Multi-stage build (`rust:1.95` builder → `ubuntu:24.04` runtime, non-root user `opcgw` UID 10001). Exposes ports 4840 (OPC UA) and 8080 (web UI). Mounts `log/`, `config/`, `pki/`, `data/` as volumes (the `data/` mount is required — it holds the authoritative SQLite database).
 
 **docker-compose.yml:** Single service `opcgw`, restart always, ports 4840:4840 + 8080:8080.
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -30,7 +30,7 @@ cargo build --release
 ### 2. Docker
 
 **Dockerfile** uses a multi-stage build:
-1. **Builder stage:** `rust:1.94.0` — installs protobuf compiler, builds release binary
+1. **Builder stage:** `rust:1.95.0` — installs protobuf compiler, builds release binary
 2. **Runtime stage:** `ubuntu:24.04` — minimal runtime with `iputils-ping`, runs as **non-root user `opcgw` (UID 10001)**
 
 The container exposes **4840** (OPC UA) and **8080** (web UI). Because it runs non-root, the host-side bind-mount targets must be owned by UID 10001 before first start:

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -6,7 +6,7 @@
 
 | Requirement | Version | Notes |
 |------------|---------|-------|
-| Rust toolchain | >= 1.94.0 | Install via [rustup](https://rustup.rs/) |
+| Rust toolchain | >= 1.95.0 | Install via [rustup](https://rustup.rs/) |
 | Protobuf compiler | protoc | Required for building proto definitions |
 | cargo-make | Latest | Optional, for task runner (`cargo install cargo-make`) |
 | grcov | Latest | Optional, for coverage reports (`cargo install grcov`) |
@@ -31,7 +31,7 @@
 
 3. **Verify Rust toolchain:**
    ```bash
-   rustc --version   # Should be >= 1.94.0
+   rustc --version   # Should be >= 1.95.0
    cargo --version
    ```
 
@@ -144,4 +144,4 @@ docker compose up -d
 #   ./data   → /usr/local/bin/data   (required — SQLite DB persistence)
 ```
 
-The Docker image uses a multi-stage build: Rust 1.94.0 for compilation, `ubuntu:24.04` for runtime, running as **non-root user `opcgw` (UID 10001)**. It exposes **4840** (OPC UA) and **8080** (web UI). Bind-mount targets must be `chown`'d to UID 10001 before first start; see the deployment guide for the full first-deploy checklist.
+The Docker image uses a multi-stage build: Rust 1.95.0 for compilation, `ubuntu:24.04` for runtime, running as **non-root user `opcgw` (UID 10001)**. It exposes **4840** (OPC UA) and **8080** (web UI). Bind-mount targets must be `chown`'d to UID 10001 before first start; see the deployment guide for the full first-deploy checklist.

--- a/docs/manual/latex/body.tex
+++ b/docs/manual/latex/body.tex
@@ -88,7 +88,7 @@ Outbound TCP to the ChirpStack gRPC endpoint (typically port 8080) and inbound T
 \item
   \emph{OS} --- Linux (Debian, Ubuntu, CentOS, Alpine), macOS, or Windows with Docker. The reference deployment uses Linux containers.
 \item
-  \emph{Runtime} --- Docker, using the published image (\texttt{docker.io/gcorbaz/opcgw:2.1}, mirrored at \texttt{ghcr.io/guycorbaz/opcgw:2.1}; multi-arch \texttt{linux/amd64} + \texttt{linux/arm64}). See \hyperref[ch-installation]{Installation}. Building from source is also possible (Rust 1.94.0+ and the \texttt{protobuf-compiler} / \texttt{libssl-dev} / \texttt{pkg-config} packages) for platforms the prebuilt image does not cover.
+  \emph{Runtime} --- Docker, using the published image (\texttt{docker.io/gcorbaz/opcgw:2.1}, mirrored at \texttt{ghcr.io/guycorbaz/opcgw:2.1}; multi-arch \texttt{linux/amd64} + \texttt{linux/arm64}). See \hyperref[ch-installation]{Installation}. Building from source is also possible (Rust 1.95.0+ and the \texttt{protobuf-compiler} / \texttt{libssl-dev} / \texttt{pkg-config} packages) for platforms the prebuilt image does not cover.
 \item
   \emph{SQLite} --- bundled via \texttt{rusqlite}\textquotesingle s \texttt{bundled} feature; no separate SQLite installation is needed at runtime. The \texttt{sqlite3} CLI is recommended on the operator host for the migration pre-flight script (\hyperref[ch-upgrade]{Upgrade and Migration}).
 \item

--- a/docs/manual/opcgw-user-manual.xml
+++ b/docs/manual/opcgw-user-manual.xml
@@ -350,7 +350,7 @@
             <literal>ghcr.io/guycorbaz/opcgw:2.1</literal>; multi-arch
             <literal>linux/amd64</literal> + <literal>linux/arm64</literal>).
             See <xref linkend="ch-installation"/>. Building from source is
-            also possible (Rust 1.94.0+ and the
+            also possible (Rust 1.95.0+ and the
             <literal>protobuf-compiler</literal> /
             <literal>libssl-dev</literal> / <literal>pkg-config</literal>
             packages) for platforms the prebuilt image does not

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -12,7 +12,7 @@ The project was born from a real-world need: controlling LoRa watering valves in
 
 | Category | Technology | Version | Notes |
 |----------|-----------|---------|-------|
-| Language | Rust | 2021 edition | Builder/MSRV rustc 1.94.0 |
+| Language | Rust | 2021 edition | Builder/MSRV rustc 1.95.0 |
 | Async Runtime | Tokio | 1.50.0 | Full features, multi-thread |
 | gRPC | Tonic | 0.14.5 | ChirpStack API client |
 | Protobuf | tonic-build | 0.14.5 | Build-time proto compilation |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ permalink: /quickstart/
 
 ### Prerequisites
 
-- Rust 1.94.0+ ([Install](https://rustup.rs/))
+- Rust 1.95.0+ ([Install](https://rustup.rs/))
 - Docker & Docker Compose (optional, for containerized deployment)
 - Running ChirpStack 4 instance with accessible gRPC API
 - OPC UA client software (Ignition, KEPServerEx, UA Expert, etc.) for testing

--- a/docs/source-tree-analysis.md
+++ b/docs/source-tree-analysis.md
@@ -62,7 +62,7 @@ opcgw/
 ├── build.rs                      # Build script: compiles .proto files with tonic-build
 ├── Cargo.toml                    # Rust package manifest (dependencies, profiles)
 ├── Cargo.lock                    # Dependency lock file
-├── Dockerfile                    # Multi-stage Docker build (rust:1.94 → ubuntu:24.04, non-root)
+├── Dockerfile                    # Multi-stage Docker build (rust:1.95 → ubuntu:24.04, non-root)
 ├── docker-compose.yml            # Docker Compose: exposes port 4840, mounts config/log/pki
 ├── Makefile.toml                 # cargo-make task definitions (test, coverage)
 ├── README.md                     # Project README with setup and usage instructions


### PR DESCRIPTION
## Summary

Dependency modernization, folded into one branch. **Zero opcgw source changes**; `cargo build` + `cargo clippy --all-targets -D warnings` + full `cargo test` all clean.

### async-opcua 0.17.1 → 0.19.0 ([#165](https://github.com/guycorbaz/opcgw/issues/165))
Picks up the 0.18/0.19 keep-alive (the #155 area), subscription, and security fixes (`CreateSession` cert verification, `ActivateSession` nonce-reuse prevention, monitored-item race, sequence-number desync). The breaking client-API change (`Error` vs `StatusCode`) does not intersect opcgw's usage.

### Dependency refresh — Batch A ([#159](https://github.com/guycorbaz/opcgw/issues/159))
- **rusqlite** 0.38 → **0.40.1** — bundled SQLite 3.53.2 + SAVEPOINT SQL-injection fix. Breaking changes are VTab-only (unused); custom `ToSql`/`FromSql` + CHECK-constraint tests unaffected.
- **tower-http** 0.6 → **0.7** — only `ServeDir` + `SetResponseHeaderLayer` used; no breaking layers, no forced axum bump.
- **reqwest** 0.12 → **0.13** — dev-only; `default-features=false` + no TLS/query/form dodges every break.
- Compat sweep (thiserror 2.0.19, etc.) resolved automatically (Cargo.lock gitignored).

### MSRV 1.94.0 → 1.95.0
Raised across `Cargo.toml`, both CI workflows, `Dockerfile` default, `CLAUDE.md`, and all developer docs (historical Epic-1 records left intact). Prerequisite for the crypto refresh **Batch B** (getrandom/sha2/hmac/constant_time_eq — separate PR; needs the MSRV bump). **toml 1.x deferred** (blocked on figment; #159).

## Note
Data-plane dependency (async-opcua) → **soak on panoramix after rc3** before promotion to stable; intended for a future rc (e.g. rc4). Full per-library impact analysis is recorded in #159.

Refs #165, #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)