### PR TITLE
chore(#159): crypto dependency refresh — Batch B (getrandom/sha2/hmac/constant_time_eq)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,13 @@ prost = "0.14"
 prost-types = "0.14"
 tonic-prost = "0.14"
 async-opcua = { version = "0.19.0", features = ["server"] }
-constant_time_eq = "0.3"
-hmac = "0.12"
+constant_time_eq = "0.5"
+hmac = "0.13"
 # Story 7-2 + 9-1: per-process HMAC keying via OS RNG. Pinned to 0.2
 # explicitly because `getrandom` 0.3 renamed the entry point from
 # `getrandom(&mut [u8])` to `fill(&mut [u8])`; a transitive bump
 # would silently break compilation. Story 9-1 review iter-1 patch.
-getrandom = "0.2"
+getrandom = "0.4"
 clap = { version = "4.6.0", features = ["derive"] }
 local-ip-address = "0.6.5"
 url = "2.5.7"
@@ -49,7 +49,7 @@ serde_json = "1.0.132"
 # endpoint (the canonical Rust TOML library; already present transitively via
 # figment's `toml` feature).
 toml = "0.8"
-sha2 = "0.10.8"
+sha2 = "0.11"
 dashmap = "6.1"
 
 # Dependencies for later stories (added now, not yet used)

--- a/src/opc_ua_auth.rs
+++ b/src/opc_ua_auth.rs
@@ -129,7 +129,7 @@ impl OpcgwAuthManager {
         // is NOT a configured credential, so reject-all stays in force until the
         // operator applies a real password via `/setup`.
         let mut hmac_key = [0u8; 32];
-        getrandom::getrandom(&mut hmac_key)
+        getrandom::fill(&mut hmac_key)
             .expect("system RNG must produce 32 bytes for HMAC key");
         let user_digest = hmac_sha256(&hmac_key, config.opcua.user_name.as_bytes());
         let pass_digest = hmac_sha256(&hmac_key, config.opcua.user_password.as_bytes());

--- a/src/security_hmac.rs
+++ b/src/security_hmac.rs
@@ -18,7 +18,9 @@
 //! one implementation. Per the Phase-B carry-forward rule
 //! (`epics.md:782`): reuse, don't roll new.
 
-use hmac::{Hmac, Mac};
+// hmac 0.13 / digest 0.11: `new_from_slice` lives on the `KeyInit` trait,
+// which is no longer implied by `Mac` — it must be in scope explicitly.
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 type HmacSha256 = Hmac<Sha256>;

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -255,7 +255,14 @@ impl Command {
         let content = format!("{}{}{}", device_id, command_name, params_json);
         let mut hasher = Sha256::new();
         hasher.update(content.as_bytes());
-        format!("{:x}", hasher.finalize())
+        // digest 0.11 (sha2 0.11) returns a `hybrid_array::Array`, which — unlike
+        // the old `GenericArray` — does not implement `LowerHex`; hex-encode the
+        // fixed 32-byte digest explicitly instead of `format!("{:x}", …)`.
+        hasher
+            .finalize()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
     }
 }
 

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -213,7 +213,7 @@ impl WebAuthState {
     /// empty credentials.
     pub fn new_with_fresh_key(user: &str, password: &str, realm: String) -> Self {
         let mut hmac_key = [0u8; 32];
-        getrandom::getrandom(&mut hmac_key)
+        getrandom::fill(&mut hmac_key)
             .expect("system RNG must produce 32 bytes for HMAC key");
         let user_digest = hmac_sha256(&hmac_key, user.as_bytes());
         let pass_digest = hmac_sha256(&hmac_key, password.as_bytes());
@@ -260,7 +260,7 @@ impl WebAuthState {
         is_first_run: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Self {
         // Iter-1 code review M9 fix: pre-fix `for_first_run` invoked
-        // `getrandom::getrandom` THREE times — once for `hmac_key`,
+        // `getrandom::fill` THREE times — once for `hmac_key`,
         // twice for throwaway-user + throwaway-pass digests. The
         // throwaway digests are NEVER COMPARED in first-run mode
         // (the auth middleware's `is_first_run && bypass_path` short-
@@ -273,7 +273,7 @@ impl WebAuthState {
         // compared, they're HMAC-of-zeros under a random key so
         // operationally indistinguishable from random bytes.
         let mut hmac_key = [0u8; 32];
-        getrandom::getrandom(&mut hmac_key)
+        getrandom::fill(&mut hmac_key)
             .expect("system RNG must produce 32 bytes for HMAC key");
         let throwaway_zeros = [0u8; 32];
         let user_digest = hmac_sha256(&hmac_key, &throwaway_zeros);


### PR DESCRIPTION
## Summary

Batch B of the dependency refresh (#159) — the RustCrypto/auth stack. **Stacked on #166** (needs its MSRV 1.95 bump). Kept a separate PR because it is security-adjacent.

- **getrandom** 0.2 → 0.4 — `getrandom()` → `fill()` rename at 3 call sites (`web/auth.rs:216,276`, `opc_ua_auth.rs:132`) + a doc comment.
- **sha2** 0.10 → 0.11 **+ hmac** 0.12 → 0.13 (digest 0.11, bumped together):
  - `security_hmac.rs` — `new_from_slice` moved to `KeyInit` (no longer implied by `Mac`); added the import.
  - `storage/types.rs` — digest 0.11 returns `hybrid_array::Array` (no `LowerHex`); explicit hex-encode. **Byte-identical output** → stored content-hashes unaffected.
- **constant_time_eq** 0.3 → 0.5 — no code change; drove the MSRV → 1.95.

## Notes
- `async-opcua-crypto` 0.19 + `rsa` 0.9 still pin sha2 0.10 / hmac 0.12 / digest 0.10, so those majors **coexist** in the tree (compiles fine) until those lower crates move to digest 0.11.
- `cargo build` + `cargo clippy --all-targets -D warnings` + full `cargo test` all clean.
- Merge order: **#166 → this**. Soak with the async-opcua rc before promoting to stable.

Refs #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)