### PR TITLE
Epic J security review: close a fourth allowlist bypass + env-scanner drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OPCGW_WEB__AUTH_REALM` — **not an exhaustive list**: the allowlist above is
   the authority, and every ignored var is named individually in the boot log.
 
-  Two specific traps:
+  Two specific traps (plus the **security-flag checklist** in `docs/security.md`
+  — if you hardened `trust_client_cert`, `check_cert_time` or `allowed_origins`
+  through `.env`, that hardening is dropped unless you set it on the Admin page
+  first):
   - **`OPCGW_OPCUA__USER_NAME` is also your web-UI login name.** After the
     upgrade it comes from the Admin page (default `opcua-user`), while the
     password may still come from the environment. The gateway logs an

--- a/docs/security.md
+++ b/docs/security.md
@@ -418,6 +418,26 @@ multi-user RBAC). Configure via:
 | Field                   | Env var                       | Notes                                                      |
 |-------------------------|-------------------------------|------------------------------------------------------------|
 | `[opcua].user_name`     | ~~`OPCGW_OPCUA__USER_NAME`~~  | **v2.8.0: env override IGNORED** (web-Admin-managed, #169). This is also the web-UI login name — check it on the Admin page before upgrading. |
+
+> **⚠️ v2.8.0 upgrade checklist — security-relevant env overrides.** The v2.8.0
+> env allowlist (#169) ignores every `OPCGW_OPCUA__*` / `OPCGW_WEB__*` variable
+> except `OPCGW_OPCUA__USER_PASSWORD`, `OPCGW_OPCUA__HOST_PORT` and
+> `OPCGW_WEB__ENABLED`/`BIND_ADDRESS`/`PORT`. If you **hardened** a deployment
+> through `.env` while the seed config or SQLite still holds a laxer value, the
+> laxer value takes effect after the upgrade. Diff **every** `OPCGW_OPCUA__*` and
+> `OPCGW_WEB__*` variable in your `.env` against the Admin-page value **before**
+> upgrading — the security-relevant ones are:
+>
+> | Field | Risk if the env value is dropped |
+> |-------|----------------------------------|
+> | `[opcua].trust_client_cert` | The shipped seed is `true` (accepts **any** client certificate without validation). An `OPCGW_OPCUA__TRUST_CLIENT_CERT=false` hardening is ignored after upgrade. |
+> | `[opcua].check_cert_time` | Certificate validity-period checking silently reverts to the stored value. |
+> | `[web].allowed_origins` | An env-narrowed CSRF origin allowlist reverts to the broader stored list. |
+> | `[web].auth_realm` | Cosmetic, but changes the browser credential prompt. |
+> | `[opcua].host_ip_address` | Advertised endpoint host (#163) — reverts to the stored value. |
+>
+> Each ignored variable is named individually by an `env_var_ignored` WARN at
+> boot, so the first startup after the upgrade is also a checklist.
 | `[opcua].user_password` | `OPCGW_OPCUA__USER_PASSWORD`  | **Always set via env var** — the placeholder in the shipped TOML is rejected at startup. |
 
 Internally the user-token id is `default-user`

--- a/src/chirpstack.rs
+++ b/src/chirpstack.rs
@@ -2841,7 +2841,14 @@ pub(crate) async fn deliver_one(
                 command_id = command.id,
                 "Failed to enqueue command; marking command Failed"
             );
-            let reason = e.to_string();
+            // Epic J security review LOW-1: this reason is REMOTE-supplied
+            // (a `tonic::Status` from ChirpStack) and is persisted into
+            // `command_queue.error_message`, which is served to operators over
+            // OPC UA. Scrub it like the J-0 error-feed path does — Bearer
+            // redaction, control-character strip, length bound — so a hostile
+            // or broken peer cannot inject unbounded control text into an
+            // operator-facing field.
+            let reason = crate::utils::sanitize_error_message(&e.to_string());
             if let Err(e2) = backend
                 .async_store()
                 .update_command_status(command.id, CommandStatus::Failed, Some(reason.clone()))

--- a/src/chirpstack_dispatch.rs
+++ b/src/chirpstack_dispatch.rs
@@ -131,17 +131,25 @@ fn is_provably_unsent(status: &tonic::Status) -> bool {
             return true;
         }
         if let Some(io) = err.downcast_ref::<std::io::Error>() {
+            // ONLY kinds that are unambiguous at the socket level: the peer
+            // actively refused, or the route/host never existed. Epic J
+            // security review LOW-2: `NotConnected` and `TimedOut` were also
+            // listed, argued safe because the 10 s RPC deadline preempts
+            // post-send kernel timeouts — but that reasoning depends on
+            // hyper-util internals, and if either kind ever surfaced AFTER the
+            // request was written it would flip an ambiguous failure into the
+            // retry-safe class and re-open the double-actuation window. They
+            // are dropped: the cost is that a blackholed connect fails
+            // terminally ("delivery uncertain") instead of retrying, which is
+            // the safe direction for hardware actuation. The common
+            // ChirpStack-restart shapes (refused, DNS) are unaffected, and a
+            // COLD connect failure is classified unreachable at
+            // client-creation regardless of kind.
             return matches!(
                 io.kind(),
                 std::io::ErrorKind::ConnectionRefused
                     | std::io::ErrorKind::HostUnreachable
                     | std::io::ErrorKind::NetworkUnreachable
-                    | std::io::ErrorKind::NotConnected
-                    // Connect-phase timeout (blackholed SYN). Post-send kernel
-                    // timeouts (~minutes) cannot surface here: the 10 s
-                    // ENQUEUE_RPC_TIMEOUT tokio arm preempts them, and its
-                    // elapsed error carries no io source at all.
-                    | std::io::ErrorKind::TimedOut
             );
         }
         source = err.source();
@@ -1380,14 +1388,20 @@ mod tests {
         )));
         assert!(is_provably_unsent(&refused), "refused connect = nothing sent");
 
-        let reset = tonic::Status::from_error(Box::new(std::io::Error::new(
+        for ambiguous in [
             std::io::ErrorKind::ConnectionReset,
-            "connection reset by peer",
-        )));
-        assert!(
-            !is_provably_unsent(&reset),
-            "a reset can happen AFTER the request went out — must stay ambiguous"
-        );
+            // Dropped from the allowlist by the Epic J security review (LOW-2):
+            // their post-send impossibility rested on hyper-util internals.
+            std::io::ErrorKind::NotConnected,
+            std::io::ErrorKind::TimedOut,
+        ] {
+            let status =
+                tonic::Status::from_error(Box::new(std::io::Error::new(ambiguous, "boom")));
+            assert!(
+                !is_provably_unsent(&status),
+                "{ambiguous:?} can occur AFTER the request went out — must stay ambiguous"
+            );
+        }
 
         let plain = tonic::Status::unavailable("service unavailable");
         assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1128,10 +1128,22 @@ pub(crate) fn env_post_prefix_key_passes(raw: &str) -> bool {
     use crate::storage::migrate_singleton_config::env_key_allowed;
     match env_post_prefix_to_section_key(raw) {
         Some((section, key)) => env_key_allowed(&section, &key),
-        // Addresses no section field (short form, or empty segments figment
-        // itself drops) — nothing to protect.
-        None => true,
+        // A separator-less key that IS a section name addresses the WHOLE
+        // section, because figment parses env VALUES into structured dicts
+        // (`value/parse.rs`): `OPCGW_CHIRPSTACK='{polling_frequency=99}'`
+        // deep-merges over the SQLite provider and sets any number of blocked
+        // fields at once — a strictly more powerful bypass than the `__`/`.`/
+        // whitespace shapes, and silent (Epic J security review HIGH-1).
+        None => !env_names_a_known_section(raw),
     }
+}
+
+/// Does this post-prefix key name a whole web-editable section (rather than a
+/// field inside one)? Such a key must be blocked: figment would merge a dict
+/// value straight over the Admin-page settings.
+pub(crate) fn env_names_a_known_section(raw: &str) -> bool {
+    use crate::storage::migrate_singleton_config::KNOWN_SECTIONS;
+    KNOWN_SECTIONS.contains(&raw.trim().to_lowercase().as_str())
 }
 
 /// The single `OPCGW_*` env provider for BOTH production figment stacks
@@ -1504,18 +1516,20 @@ impl AppConfig {
 
         // Collect (env_var, section, key, env_value, db_value) for every OPCGW_*
         // env var that maps to a web-editable field ALSO present in singleton_config.
+        //
+        // Epic J security review MEDIUM-1: this scanner originally had its own
+        // ad-hoc parsing (`vars()`, case-sensitive `strip_prefix`, `__`-only,
+        // no trim) — the very drift the J-2 review fixed in its two siblings.
+        // It now shares `env_name_to_section_key`, so all THREE scanners and
+        // the provider filter classify identically. `vars_os()` also removes
+        // the boot-path panic on a non-UTF-8 environment variable.
         let mut shadowed: Vec<(String, String, String, String, String)> = Vec::new();
-        for (name, env_value) in std::env::vars() {
-            let Some(rest) = name.strip_prefix("OPCGW_") else {
+        for (name_os, value_os) in std::env::vars_os() {
+            let name = name_os.to_string_lossy().into_owned();
+            let Some((section, key)) = env_name_to_section_key(&name) else {
                 continue;
             };
-            // Only `OPCGW_<SECTION>__<KEY>` maps to a singleton field. Short forms
-            // like `OPCGW_LOG_LEVEL` have no `__` separator — skip them.
-            let Some((section_part, key_part)) = rest.split_once("__") else {
-                continue;
-            };
-            let section = section_part.to_lowercase();
-            let key = key_part.to_lowercase();
+            let env_value = value_os.to_string_lossy().into_owned();
             if !KNOWN_SECTIONS.contains(&section.as_str()) {
                 continue;
             }
@@ -1537,7 +1551,13 @@ impl AppConfig {
                 .iter()
                 .find(|(s, k, _)| s == &section && k == &key)
             {
-                shadowed.push((name, section, key, env_value, db_value.clone()));
+                shadowed.push((
+                    name.trim().to_string(),
+                    section,
+                    key,
+                    env_value,
+                    db_value.clone(),
+                ));
             }
         }
 
@@ -1622,7 +1642,19 @@ impl AppConfig {
             // Short forms (`OPCGW_LOG_LEVEL`, budget/cap knobs) resolve to
             // `None`: they address no section field, the filter passes them,
             // so they are NOT "ignored".
-            let Some((section, key)) = env_name_to_section_key(&name) else {
+            let Some((section, key)) = env_name_to_section_key(&name).or_else(|| {
+                // Section-level key (Epic J security review HIGH-1): report it
+                // with an empty field so the operator sees the whole-section
+                // override was dropped, instead of it vanishing silently.
+                let trimmed = name.trim();
+                let rest = trimmed.get(ENV_PREFIX.len()..).filter(|_| {
+                    trimmed
+                        .get(..ENV_PREFIX.len())
+                        .is_some_and(|p| p.eq_ignore_ascii_case(ENV_PREFIX))
+                })?;
+                env_names_a_known_section(rest)
+                    .then(|| (rest.trim().to_lowercase(), "*".to_string()))
+            }) else {
                 continue;
             };
             // Unknown sections were never mergeable into the editable set and
@@ -6266,6 +6298,20 @@ mod tests {
             ("OPCGW_GLOBAL__DEBUG", true),
             ("OPCGW_OPCUA__HOST_IP_ADDRESS", true),
             ("OPCGW_WEB__AUTH_REALM", true),
+            // SECTION-LEVEL keys (Epic J security review HIGH-1): figment
+            // parses env VALUES into dicts, so `OPCGW_CHIRPSTACK={...}`
+            // overrides ANY number of blocked fields at once. Must be
+            // blocked AND reported.
+            ("OPCGW_CHIRPSTACK", true),
+            ("OPCGW_OPCUA", true),
+            ("OPCGW_WEB", true),
+            ("OPCGW_GLOBAL", true),
+            ("opcgw_opcua", true),
+            (" OPCGW_WEB ", true),
+            // ...but a section-less key that is NOT a section stays a
+            // pass-through short form.
+            ("OPCGW_LOGGING", false),
+            ("OPCGW_STORAGE", false),
             // Whitespace AFTER the prefix (J-2 review iter-2): figment trims
             // the key a second time, post-prefix-strip, so these address the
             // real blocked field. Before the fix the untrimmed section
@@ -6351,6 +6397,70 @@ mod tests {
                     "[logging] is outside KNOWN_SECTIONS — its env override must still apply"
                 );
                 assert_eq!(logging.level.as_deref(), Some("debug"));
+            },
+        );
+    }
+
+    /// Epic J security review (HIGH-1, end-to-end): a SECTION-level env var
+    /// carrying a figment dict value must not override blocked fields.
+    /// figment parses env values into structured `Value`s, so
+    /// `OPCGW_CHIRPSTACK='{polling_frequency=99,server_address="..."}'`
+    /// deep-merged over everything — one variable defeating the whole
+    /// allowlist, silently. Non-overlapping fixture values (TOML 10 /
+    /// env 99) so this cannot pass on the broken path.
+    #[test]
+    #[serial_test::serial]
+    fn j2_section_level_dict_env_var_cannot_bypass_the_allowlist() {
+        let toml = r#"
+            [global]
+            debug = false
+            [chirpstack]
+            server_address = "http://from-toml:8080"
+            api_token = "x"
+            tenant_id = "t"
+            polling_frequency = 10
+            retry = 1
+            delay = 1
+            [opcua]
+            application_name = "A"
+            application_uri = "urn:a"
+            product_uri = "urn:p"
+            diagnostics_enabled = false
+            create_sample_keypair = true
+            certificate_path = "c"
+            private_key_path = "k"
+            trust_client_cert = true
+            check_cert_time = false
+            pki_dir = "pki"
+            user_name = "from-toml"
+            user_password = "p"
+        "#;
+        temp_env::with_vars(
+            [
+                (
+                    "OPCGW_CHIRPSTACK",
+                    Some("{polling_frequency=99,server_address=\"http://pwned:1\"}"),
+                ),
+                ("OPCGW_OPCUA", Some("{user_name=\"attacker\"}")),
+            ],
+            || {
+                let config: AppConfig = Figment::new()
+                    .merge(Toml::string(toml))
+                    .merge(super::opcgw_env_provider())
+                    .extract()
+                    .expect("config parses with section-level env vars present");
+                assert_eq!(
+                    config.chirpstack.polling_frequency, 10,
+                    "a section-level dict env var must not override a blocked field"
+                );
+                assert_eq!(
+                    config.chirpstack.server_address, "http://from-toml:8080",
+                    "a section-level dict env var must not override a blocked field"
+                );
+                assert_eq!(
+                    config.opcua.user_name, "from-toml",
+                    "a section-level dict env var must not override the web login name"
+                );
             },
         );
     }


### PR DESCRIPTION
## Summary

The mandatory pre-retrospective security review (CLAUDE.md epic-completion gate) over the full Epic J diff returned **FAIL on checklist item 5 (access control)**. This PR fixes every finding.

**HIGH-1 — a fourth, more powerful allowlist bypass, empirically demonstrated by the reviewer.** figment parses env *values* into structured `Value`s, so a **section-level** variable carrying a dict — `OPCGW_CHIRPSTACK='{polling_frequency=99,server_address="http://pwned:1"}'` — deep-merged straight over the SQLite provider, setting **any number** of blocked fields at once, including `[opcua].user_name` (the web Basic-auth login) and `[web].allowed_origins`. The separator-less key hit the filter's fail-open `None` arm, and the reporter skipped it, so it was also **silent** — the exact class J-2 exists to eliminate. Now blocked when the key names a `KNOWN_SECTION`, and reported. Mutation-verified end-to-end with the reviewer's own exploit values.

**MEDIUM-1 — the third env scanner never adopted the shared normalizer.** `maybe_warn_env_shadows_singleton` still used `std::env::vars()` (which **panics the boot** on any non-UTF-8 environment variable) plus a case-sensitive, `__`-only, untrimmed parse that under-reported shadowed allowlisted keys. All three scanners and the provider filter now classify identically.

**MEDIUM-2 / LOW-1 / LOW-2** — a `docs/security.md` upgrade checklist for security-relevant flags that silently revert if they were hardened via `.env` (`trust_client_cert`, `check_cert_time`, `allowed_origins`); `sanitize_error_message` applied to the remote-supplied gRPC text J-1 persists into an operator-facing field; and two io-error kinds dropped from the retry-safe set because their post-send impossibility rested on hyper-util internals (failing toward "ask a human" is correct for hardware actuation).

## Verification

- `cargo test` **1919/0**; `cargo clippy --all-targets -- -D warnings` clean.
- Every bypass shape now has a regression guard, and the drift-guard matrix covers section-level, dotted, whitespace, cased and empty-segment shapes.
- Checklist items 1, 2, 3, 4, 6 passed the review as-is; item 5 is addressed here.

Refs #169, Refs #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)